### PR TITLE
feat(data): RSC prefetch + TanStack Query Hydration data layer

### DIFF
--- a/apps/web/src/app/api/about/route.ts
+++ b/apps/web/src/app/api/about/route.ts
@@ -1,30 +1,9 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
+import { getAbout } from "@/server/queries/about";
 
 export async function GET() {
   try {
-    const [aboutSections, cvInfo, techStacks, socialLinks, loves] =
-      await Promise.all([
-        prisma.aboutSection.findMany(),
-        prisma.cvInfo.findFirst(),
-        prisma.techStack.findMany({ orderBy: { order: "asc" } }),
-        prisma.socialLink.findMany({ orderBy: { order: "asc" } }),
-        prisma.love.findMany({ orderBy: { order: "asc" } }),
-      ]);
-
-    // Parse the JSON string for clubs in loves
-    const lovesWithParsedClubs = loves.map((love) => ({
-      ...love,
-      clubs: typeof love.clubs === "string" ? JSON.parse(love.clubs) : love.clubs,
-    }));
-
-    return NextResponse.json({
-      aboutSections,
-      cvInfo,
-      techStacks,
-      socialLinks,
-      loves: lovesWithParsedClubs,
-    });
+    return NextResponse.json(await getAbout());
   } catch (error) {
     console.error("Error fetching about data:", error);
     return NextResponse.json(

--- a/apps/web/src/app/api/experiences/route.ts
+++ b/apps/web/src/app/api/experiences/route.ts
@@ -1,14 +1,9 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
+import { getExperiences } from "@/server/queries/experiences";
 
 export async function GET() {
   try {
-    const experiences = await prisma.experience.findMany({
-      where: { isPublished: true },
-      orderBy: { order: "asc" },
-    });
-
-    return NextResponse.json(experiences);
+    return NextResponse.json(await getExperiences());
   } catch (error) {
     console.error("Error fetching experiences:", error);
     return NextResponse.json(

--- a/apps/web/src/app/api/projects/[slug]/route.ts
+++ b/apps/web/src/app/api/projects/[slug]/route.ts
@@ -1,31 +1,16 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
+import { getProjectBySlug } from "@/server/queries/projects";
 
 export async function GET(
-  request: Request,
+  _request: Request,
   { params }: { params: Promise<{ slug: string }> }
 ) {
   try {
     const { slug } = await params;
-
-    const project = await prisma.project.findUnique({
-      where: { slug },
-      include: {
-        highlights: {
-          include: {
-            images: {
-              orderBy: { order: "asc" },
-            },
-          },
-          orderBy: { order: "asc" },
-        },
-      },
-    });
-
+    const project = await getProjectBySlug(slug);
     if (!project) {
       return NextResponse.json({ error: "Project not found" }, { status: 404 });
     }
-
     return NextResponse.json(project);
   } catch (error) {
     console.error("Error fetching project:", error);

--- a/apps/web/src/app/api/projects/route.ts
+++ b/apps/web/src/app/api/projects/route.ts
@@ -1,21 +1,9 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
+import { getProjects } from "@/server/queries/projects";
 
 export async function GET() {
   try {
-    const projects = await prisma.project.findMany({
-      where: { isPublished: true },
-      select: {
-        id: true,
-        slug: true,
-        title: true,
-        description: true,
-        image: true,
-      },
-      orderBy: { createdAt: "desc" },
-    });
-
-    return NextResponse.json(projects);
+    return NextResponse.json(await getProjects());
   } catch (error) {
     console.error("Error fetching projects:", error);
     return NextResponse.json(

--- a/apps/web/src/app/api/skills/route.ts
+++ b/apps/web/src/app/api/skills/route.ts
@@ -1,13 +1,9 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
+import { getSkills } from "@/server/queries/skills";
 
 export async function GET() {
   try {
-    const skills = await prisma.skill.findMany({
-      orderBy: { order: "asc" },
-    });
-
-    return NextResponse.json(skills);
+    return NextResponse.json(await getSkills());
   } catch (error) {
     console.error("Error fetching skills:", error);
     return NextResponse.json(

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Outfit } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { ThemeProvider } from "./providers/ThemeProvider";
+import { QueryProvider } from "./providers/QueryProvider";
 import "./globals.css";
 
 const geistOutfit = Outfit({
@@ -23,7 +24,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistOutfit.variable} antialiased`}>
-        <ThemeProvider>{children}</ThemeProvider>
+        <QueryProvider>
+          <ThemeProvider>{children}</ThemeProvider>
+        </QueryProvider>
         <Analytics />
       </body>
     </html>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,5 @@
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+
 import { PageWrapper } from "@/components/organisms/PageWrapper";
 import { Hero3D } from "@/components/sections/hero3d";
 import { Projects } from "@/components/sections/projects";
@@ -5,21 +7,49 @@ import { About } from "@/components/sections/about";
 import { Experiences } from "@/components/sections/experiences";
 import { Skills } from "@/components/sections/skills";
 
-const Home = () => {
+import { getQueryClient } from "@/lib/query-client";
+import { queryKeys } from "@/lib/query-keys";
+import { getProjects } from "@/server/queries/projects";
+import { getAbout } from "@/server/queries/about";
+import { getExperiences } from "@/server/queries/experiences";
+import { getSkills } from "@/server/queries/skills";
+
+export default async function Home() {
+  const queryClient = getQueryClient();
+
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.projects,
+      queryFn: getProjects,
+    }),
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.about,
+      queryFn: getAbout,
+    }),
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.experiences,
+      queryFn: getExperiences,
+    }),
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.skills,
+      queryFn: getSkills,
+    }),
+  ]);
+
   return (
-    <PageWrapper>
-      <main className="flex flex-col justify-center items-center w-full gap-16">
-        <section id="hero" className="w-full">
-          <Hero3D />
-        </section>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <PageWrapper>
+        <main className="flex flex-col justify-center items-center w-full gap-16">
+          <section id="hero" className="w-full">
+            <Hero3D />
+          </section>
 
-        <Projects />
-        <About />
-        <Experiences />
-        <Skills />
-      </main>
-    </PageWrapper>
+          <Projects />
+          <About />
+          <Experiences />
+          <Skills />
+        </main>
+      </PageWrapper>
+    </HydrationBoundary>
   );
-};
-
-export default Home;
+}

--- a/apps/web/src/app/projects/[slug]/page.tsx
+++ b/apps/web/src/app/projects/[slug]/page.tsx
@@ -1,57 +1,25 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import { prisma } from "@/lib/prisma";
+
 import { ProjectPageContent } from "@/components/organisms/ProjectPageContent";
+import { getProjectBySlug, getProjects } from "@/server/queries/projects";
 import type { ProjectDetail, ProjectHighlight } from "@/types";
 
-type ProjectWithHighlights = {
-  slug: string;
-  title: string;
-  description: string;
-  image: string;
-  company: string | null;
-  overview: string | null;
-  scope: string | null;
-  industry: string | null;
-  highlights: Array<{
-    highlightId: string;
-    title: string;
-    description: string;
-    impact: string[];
-    link: string | null;
-    images: Array<{
-      link: string;
-      isScrollable: boolean;
-    }>;
-  }>;
+type ProjectWithHighlights = NonNullable<Awaited<ReturnType<typeof getProjectBySlug>>>;
+
+export const generateStaticParams = async () => {
+  const projects = await getProjects();
+  return projects.map((project) => ({ slug: project.slug }));
 };
 
-export async function generateStaticParams() {
-  const projects = await prisma.project.findMany({
-    where: { isPublished: true },
-    select: { slug: true },
-  });
-
-  return projects.map((project) => ({
-    slug: project.slug,
-  }));
-}
-
-export async function generateMetadata({
+export const generateMetadata = async ({
   params,
 }: {
   params: Promise<{ slug: string }>;
-}): Promise<Metadata> {
+}): Promise<Metadata> => {
   const { slug } = await params;
-  const project = await prisma.project.findUnique({
-    where: { slug },
-  });
-
-  if (!project) {
-    return {
-      title: "Project Not Found",
-    };
-  }
+  const project = await getProjectBySlug(slug);
+  if (!project) return { title: "Project Not Found" };
 
   return {
     title: `${project.company} | Shendy's Portfolio`,
@@ -62,26 +30,28 @@ export async function generateMetadata({
       type: "website",
     },
   };
-}
+};
 
 const mapProjectToDetail = (data: ProjectWithHighlights): ProjectDetail => ({
   slug: data.slug,
-  company: data.company || "",
+  company: data.company ?? "",
   title: data.title,
-  overview: data.overview || "",
-  scope: data.scope || "",
-  industry: data.industry || "",
-  highlights: data.highlights.map((h): ProjectHighlight => ({
-    id: h.highlightId,
-    title: h.title,
-    description: h.description,
-    impact: h.impact,
-    images: h.images.map((img) => ({
-      link: img.link,
-      isScrollable: img.isScrollable,
-    })),
-    link: h.link || undefined,
-  })),
+  overview: data.overview ?? "",
+  scope: data.scope ?? "",
+  industry: data.industry ?? "",
+  highlights: data.highlights.map(
+    (h): ProjectHighlight => ({
+      id: h.highlightId,
+      title: h.title,
+      description: h.description,
+      impact: h.impact,
+      images: h.images.map((img) => ({
+        link: img.link,
+        isScrollable: img.isScrollable,
+      })),
+      link: h.link ?? undefined,
+    })
+  ),
 });
 
 const ProjectPage = async ({
@@ -90,26 +60,10 @@ const ProjectPage = async ({
   params: Promise<{ slug: string }>;
 }) => {
   const { slug } = await params;
-
-  const project = await prisma.project.findUnique({
-    where: { slug },
-    include: {
-      highlights: {
-        include: {
-          images: {
-            orderBy: { order: "asc" },
-          },
-        },
-        orderBy: { order: "asc" },
-      },
-    },
-  });
-
+  const project = await getProjectBySlug(slug);
   if (!project) return notFound();
 
-  const projectDetail = mapProjectToDetail(project as ProjectWithHighlights);
-
-  return <ProjectPageContent project={projectDetail} />;
+  return <ProjectPageContent project={mapProjectToDetail(project)} />;
 };
 
 export default ProjectPage;

--- a/apps/web/src/app/providers/QueryProvider.tsx
+++ b/apps/web/src/app/providers/QueryProvider.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { getQueryClient } from "@/lib/query-client";
+
+export const QueryProvider = ({ children }: { children: ReactNode }) => {
+  // useState ensures we get a stable client reference for the lifetime of the
+  // component on the client; on the server, getQueryClient() always returns a
+  // fresh instance per request.
+  const [queryClient] = useState(getQueryClient);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {process.env.NODE_ENV === "development" && (
+        <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-right" />
+      )}
+    </QueryClientProvider>
+  );
+};

--- a/apps/web/src/components/sections/about.tsx
+++ b/apps/web/src/components/sections/about.tsx
@@ -1,78 +1,31 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
 
-import { ArrowBigRight, Download } from "lucide-react";
+import {
+  ArrowBigRight,
+  Download,
+  Github,
+  Instagram,
+  Linkedin,
+  type LucideIcon,
+  Mail,
+  Twitter,
+} from "lucide-react";
 
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
 import { scrollToSection } from "@/lib/utils";
 import { useThemeContext } from "@/app/providers/ThemeProvider";
 import { SECTION_IDS, SITE_CONFIG } from "@/constants/config";
 import { SocialButton } from "@/components/molecules/SocialButton";
 import { TechStackItem } from "@/components/molecules/TechStackItem";
-import { SocialLink, TechStack, Love, CvInfo as CvInfoType, Club } from "@/types";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
-
-// Import icon components from lucide-react
-import {
-  Github,
-  Linkedin,
-  Instagram,
-  Twitter,
-  Mail,
-  LucideIcon,
-} from "lucide-react";
-
-// API Response Types
-type AboutSection = {
-  id: string;
-  key: string;
-  title: string | null;
-  content: string;
-};
-
-type CvInfoResponse = {
-  id: string;
-  title: string;
-  previewImage: string;
-  downloadPath: string;
-};
-
-type TechStackResponse = {
-  id: string;
-  name: string;
-  src: string;
-  order: number;
-};
-
-type SocialLinkResponse = {
-  id: string;
-  platform: string;
-  url: string;
-  label: string;
-  iconName: string;
-  order: number;
-};
-
-type LoveResponse = {
-  id: string;
-  mainName: string;
-  mainSrc: string;
-  clubs: Club[]; // Prisma Json type returns plain object
-  order: number;
-};
-
-type AboutApiResponse = {
-  aboutSections: AboutSection[];
-  cvInfo: CvInfoResponse;
-  techStacks: TechStackResponse[];
-  socialLinks: SocialLinkResponse[];
-  loves: LoveResponse[];
-};
+import { queryKeys } from "@/lib/query-keys";
+import type { AboutBundle } from "@/server/queries/about";
 
 const iconMap: Record<string, LucideIcon> = {
   Github,
@@ -80,6 +33,12 @@ const iconMap: Record<string, LucideIcon> = {
   Instagram,
   Twitter,
   Mail,
+};
+
+const fetchAbout = async (): Promise<AboutBundle> => {
+  const res = await fetch("/api/about");
+  if (!res.ok) throw new Error("Failed to fetch about data");
+  return res.json();
 };
 
 export const About = () => {
@@ -91,149 +50,40 @@ export const About = () => {
   });
 
   const [isHovered, setIsHovered] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [hasStartedFetching, setHasStartedFetching] = useState(false);
 
-  // Data from API
-  const [professionalBio, setProfessionalBio] = useState<{
-    title: string;
-    content: string;
-  } | null>(null);
-  const [currentLearningJourney, setCurrentLearningJourney] = useState<
-    string | null
-  >(null);
-  const [cvInfo, setCvInfo] = useState<CvInfoType | null>(null);
-  const [techStacks, setTechStacks] = useState<TechStack[]>([]);
-  const [socialLinks, setSocialLinks] = useState<SocialLink[]>([]);
-  const [loves, setLoves] = useState<Love[]>([]);
+  const { data } = useQuery({ queryKey: queryKeys.about, queryFn: fetchAbout });
 
-  useEffect(() => {
-    // Only fetch when section becomes visible and hasn't fetched yet
-    if (!isVisible || hasStartedFetching) return;
+  const view = useMemo(() => {
+    if (!data) return null;
 
-    setHasStartedFetching(true);
-
-    async function fetchAboutData() {
-      try {
-        const response = await fetch("/api/about");
-        const data: AboutApiResponse = await response.json();
-
-        // Map about sections to their keys
-        const bioSection = data.aboutSections?.find(
-          (s) => s.key === "professional_bio"
-        );
-        const learningSection = data.aboutSections?.find(
-          (s) => s.key === "current_learning"
-        );
-
-        setProfessionalBio({
-          title: bioSection?.title || "Professional Dreamer",
-          content: bioSection?.content || "",
-        });
-
-        setCurrentLearningJourney(learningSection?.content || "");
-
-        // Map CV info
-        if (data.cvInfo) {
-          setCvInfo({
-            title: data.cvInfo.title,
-            previewImage: data.cvInfo.previewImage,
-            downloadPath: data.cvInfo.downloadPath,
-          });
-        }
-
-        // Map tech stacks
-        setTechStacks(
-          data.techStacks?.map((tech) => ({
-            name: tech.name,
-            src: tech.src,
-          })) || []
-        );
-
-        // Map social links - convert iconName to actual icon component
-        setSocialLinks(
-          data.socialLinks?.map((link) => ({
-            href: link.url,
-            icon: (iconMap[link.iconName] || Mail) as React.ComponentType<{ className?: string }>,
-            label: link.label,
-          })) || []
-        );
-
-        // Map loves - Prisma Json type returns plain object, no need to parse
-        setLoves(
-          data.loves?.map((love) => ({
-            main: {
-              name: love.mainName,
-              src: love.mainSrc,
-            },
-            clubs: love.clubs,
-          })) || []
-        );
-      } catch (error) {
-        console.error("Failed to fetch about data:", error);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchAboutData();
-  }, [isVisible, hasStartedFetching]);
-
-  if (loading) {
-    return (
-      <section
-        ref={sectionRef}
-        id="about"
-        className={`w-full flex flex-col justify-center items-center py-16 px-4 sm:px-6 md:px-8 lg:px-10 xl:px-14 mx-auto rounded-[40px] md:rounded-[80px] shadow-2xl bg-accent transition-all duration-1000 ease-out ${
-          isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
-        }`}
-      >
-        <div className="max-w-6xl w-full flex flex-col gap-8 md:gap-12">
-          {/* Top row skeletons */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4 md:gap-6">
-            <Card className="lg:col-span-3 p-4 md:p-6 rounded-xl">
-              <Skeleton className="h-8 w-3/4 mb-4" />
-              <Skeleton className="h-4 w-full mb-2" />
-              <Skeleton className="h-4 w-5/6 mb-2" />
-              <Skeleton className="h-4 w-4/6" />
-            </Card>
-            <div className="lg:col-span-3 flex flex-col gap-4">
-              <div className="grid grid-cols-3 gap-4">
-                <Skeleton className="col-span-2 h-48 lg:h-56 rounded-xl" />
-                <div className="col-span-1 grid grid-cols-2 lg:grid-cols-1 gap-2">
-                  <Skeleton className="h-10 rounded-lg" />
-                  <Skeleton className="h-10 rounded-lg" />
-                  <Skeleton className="h-10 rounded-lg" />
-                  <Skeleton className="h-10 rounded-lg" />
-                </div>
-              </div>
-              <Skeleton className="h-6 w-3/4 mx-auto" />
-            </div>
-          </div>
-          {/* Bottom row skeletons */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4 md:gap-6">
-            <Card className="col-span-1 lg:col-span-2 p-4 md:p-6">
-              <Skeleton className="h-6 w-1/2 mb-4" />
-              <Skeleton className="h-40 w-full" />
-            </Card>
-            <Card className="col-span-1 lg:col-span-2 p-4 md:p-6">
-              <Skeleton className="h-6 w-1/3 mb-4 mx-auto" />
-              <div className="flex flex-wrap justify-center gap-2">
-                <Skeleton className="h-8 w-16 rounded-full" />
-                <Skeleton className="h-8 w-20 rounded-full" />
-                <Skeleton className="h-8 w-16 rounded-full" />
-                <Skeleton className="h-8 w-20 rounded-full" />
-              </div>
-            </Card>
-            <Card className="col-span-1 lg:col-span-2 p-4 md:p-6">
-              <Skeleton className="h-6 w-1/3 mb-10 ml-auto" />
-              <Skeleton className="h-16 w-16 rounded-full mx-auto" />
-            </Card>
-          </div>
-        </div>
-      </section>
+    const bioSection = data.aboutSections.find((s) => s.key === "professional_bio");
+    const learningSection = data.aboutSections.find(
+      (s) => s.key === "current_learning"
     );
-  }
+
+    return {
+      professionalBio: {
+        title: bioSection?.title ?? "Professional Dreamer",
+        content: bioSection?.content ?? "",
+      },
+      currentLearningJourney: learningSection?.content ?? "",
+      cvInfo: data.cvInfo,
+      techStacks: data.techStacks.map((t) => ({ name: t.name, src: t.src })),
+      socialLinks: data.socialLinks.map((link) => ({
+        href: link.url,
+        icon: (iconMap[link.iconName] ?? Mail) as React.ComponentType<{ className?: string }>,
+        label: link.label,
+      })),
+      loves: data.loves.map((love) => ({
+        main: { name: love.mainName, src: love.mainSrc },
+        clubs: love.clubs,
+      })),
+    };
+  }, [data]);
+
+  if (!view) return null;
+
+  const { professionalBio, currentLearningJourney, cvInfo, techStacks, socialLinks, loves } = view;
 
   return (
     <section
@@ -250,11 +100,11 @@ export const About = () => {
           <Card className="lg:col-span-3 p-4 md:p-6 rounded-xl transition-all duration-500 hover:-rotate-2 hover:scale-105 hover:shadow-xl">
             <h2 className="font-heading text-xl md:text-2xl lg:text-3xl font-bold text-foreground mb-3 md:mb-4">
               <span className="bg-gradient-to-r from-accent to-primary bg-clip-text text-transparent">
-                {professionalBio?.title}
+                {professionalBio.title}
               </span>
             </h2>
             <p className="text-muted-foreground leading-relaxed text-sm md:text-base">
-              {professionalBio?.content}
+              {professionalBio.content}
             </p>
           </Card>
 
@@ -297,8 +147,6 @@ export const About = () => {
             </div>
           </div>
         </div>
-
-        {/* --- */}
 
         {/* Bottom row */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4 md:gap-6 items-start">
@@ -344,7 +192,7 @@ export const About = () => {
   `}
               >
                 <Link
-                  href={cvInfo?.downloadPath || "#"}
+                  href={cvInfo?.downloadPath ?? "#"}
                   target="_blank"
                   download
                   className="flex items-center justify-center"
@@ -357,7 +205,7 @@ export const About = () => {
             <div className="w-full h-[150px] md:h-[200px] overflow-hidden rounded-lg shadow-md relative">
               <div className="absolute inset-0 transition-transform duration-[1500ms] ease-in-out hover:-translate-y-[100%]">
                 <Image
-                  src={cvInfo?.previewImage || ""}
+                  src={cvInfo?.previewImage ?? ""}
                   alt="CV Preview"
                   width={300}
                   height={1000}

--- a/apps/web/src/components/sections/experiences.tsx
+++ b/apps/web/src/components/sections/experiences.tsx
@@ -1,28 +1,36 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
 import { useThemeContext } from "@/app/providers/ThemeProvider";
 import { ExperienceCard } from "@/components/molecules/ExperienceCard";
-import { Experience } from "@/types";
-import { Skeleton } from "@/components/ui/skeleton";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
+import { queryKeys } from "@/lib/query-keys";
+import type { ExperienceDto } from "@/server/queries/experiences";
+import type { Experience, EmploymentType } from "@/types";
 
-type ExperienceResponse = {
-  id: string;
-  company: string;
-  companyLogo: string;
-  title: string;
-  location: string;
-  period: string;
-  current: boolean;
-  description: string;
-  responsibilities: string[];
-  projects: string[];
-  techStack: string;
-  employmentType: string;
-  isPublished: boolean;
-  order: number;
+const fetchExperiences = async (): Promise<ExperienceDto[]> => {
+  const res = await fetch("/api/experiences");
+  if (!res.ok) throw new Error("Failed to fetch experiences");
+  return res.json();
 };
+
+const mapToExperience = (raw: ExperienceDto[]): Experience[] =>
+  raw.map((exp, idx) => ({
+    id: idx + 1,
+    title: exp.title,
+    company: exp.company,
+    logo: exp.companyLogo,
+    location: exp.location,
+    period: exp.period,
+    current: exp.current,
+    description: exp.description,
+    responsibilities: exp.responsibilities,
+    projects: exp.projects,
+    techStack: exp.techStack,
+    employmentType: exp.employmentType as EmploymentType,
+  }));
 
 export const Experiences = () => {
   const { theme } = useThemeContext();
@@ -32,123 +40,20 @@ export const Experiences = () => {
     rootMargin: "100px",
   });
 
-  const [experiences, setExperiences] = useState<Experience[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [hasStartedFetching, setHasStartedFetching] = useState(false);
+  const { data: rawExperiences = [] } = useQuery({
+    queryKey: queryKeys.experiences,
+    queryFn: fetchExperiences,
+  });
 
-  const [expandedExperiences, setExpandedExperiences] = useState<number[]>([
-    1, 2, 3,
-  ]);
+  const experiences = useMemo(() => mapToExperience(rawExperiences), [rawExperiences]);
 
-  useEffect(() => {
-    // Only fetch when section becomes visible and hasn't fetched yet
-    if (!isVisible || hasStartedFetching) return;
-
-    setHasStartedFetching(true);
-
-    async function fetchExperiences() {
-      try {
-        const response = await fetch("/api/experiences");
-        const data: ExperienceResponse[] = await response.json();
-
-        // Map API response to match local data structure
-        const mappedData: Experience[] = data.map((exp, idx: number) => ({
-          id: idx + 1,
-          title: exp.title,
-          company: exp.company,
-          logo: exp.companyLogo,
-          location: exp.location,
-          period: exp.period,
-          current: exp.current,
-          description: exp.description,
-          responsibilities: exp.responsibilities,
-          projects: exp.projects,
-          techStack: exp.techStack,
-          employmentType: exp.employmentType as
-            | "Full Time"
-            | "Part Time"
-            | "Contract"
-            | "Internship",
-        }));
-
-        setExperiences(mappedData);
-      } catch (error) {
-        console.error("Failed to fetch experiences:", error);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchExperiences();
-  }, [isVisible, hasStartedFetching]);
+  const [expandedExperiences, setExpandedExperiences] = useState<number[]>([1, 2, 3]);
 
   const toggleExperience = (id: number) => {
     setExpandedExperiences((prev) =>
       prev.includes(id) ? prev.filter((eid) => eid !== id) : [...prev, id]
     );
   };
-
-  if (loading) {
-    return (
-      <section
-        ref={sectionRef}
-        id="experiences"
-        className={`relative max-w-6xl flex flex-col justify-center items-center py-16 px-6 mx-auto transition-all duration-1000 ease-out ${
-          isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
-        }`}
-      >
-        <div className="flex flex-col items-center space-y-8 w-full md:w-screen relative z-20">
-          <div className="flex flex-col items-center text-center">
-            <Skeleton className="h-12 w-48" />
-          </div>
-          <div className="space-y-4 px-1 w-full md:w-4/5">
-            {[1, 2, 3].map((i) => (
-              <div
-                key={i}
-                className="border border-border/50 rounded-lg overflow-hidden"
-              >
-                <div className="w-full p-4 flex flex-col md:flex-row md:items-center justify-between gap-4">
-                  <div className="flex items-center gap-4 flex-1 min-w-0">
-                    <Skeleton className="w-10 h-10 md:w-12 md:h-12 rounded-lg flex-shrink-0" />
-                    <div className="flex-1 min-w-0 space-y-2">
-                      <Skeleton className="h-6 w-full max-w-[200px]" />
-                      <Skeleton className="h-4 w-full max-w-[250px]" />
-                      <Skeleton className="h-4 w-full max-w-[150px]" />
-                    </div>
-                  </div>
-                  <Skeleton className="w-6 h-6 self-end md:self-center flex-shrink-0" />
-                </div>
-                {/* Expanded content skeleton */}
-                <div className="p-4 border-t border-border/50 bg-background/40 space-y-4">
-                  <Skeleton className="h-4 w-full" />
-                  <Skeleton className="h-4 w-full" />
-                  <div className="space-y-2">
-                    <Skeleton className="h-4 w-28" />
-                    <div className="space-y-2">
-                      <Skeleton className="h-4 w-full" />
-                      <Skeleton className="h-4 w-11/12" />
-                      <Skeleton className="h-4 w-10/12" />
-                    </div>
-                  </div>
-                  <div className="space-y-2">
-                    <Skeleton className="h-4 w-24" />
-                    <div className="space-y-2">
-                      <Skeleton className="h-4 w-full" />
-                      <Skeleton className="h-4 w-11/12" />
-                    </div>
-                  </div>
-                  <div className="space-y-2">
-                    <Skeleton className="h-4 w-20" />
-                    <Skeleton className="h-4 w-full" />
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-    );
-  }
 
   return (
     <section
@@ -168,18 +73,15 @@ export const Experiences = () => {
         </div>
 
         <div className="space-y-4 px-1 w-full md:w-4/5">
-          {experiences.map((exp) => {
-            const isExpanded = expandedExperiences.includes(exp.id);
-            return (
-              <ExperienceCard
-                key={exp.id}
-                experience={exp}
-                isExpanded={isExpanded}
-                onToggle={() => toggleExperience(exp.id)}
-                theme={theme}
-              />
-            );
-          })}
+          {experiences.map((exp) => (
+            <ExperienceCard
+              key={exp.id}
+              experience={exp}
+              isExpanded={expandedExperiences.includes(exp.id)}
+              onToggle={() => toggleExperience(exp.id)}
+              theme={theme}
+            />
+          ))}
         </div>
       </div>
     </section>

--- a/apps/web/src/components/sections/projects.tsx
+++ b/apps/web/src/components/sections/projects.tsx
@@ -1,9 +1,18 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+
 import { ProjectCard } from "@/components/molecules/ProjectCard";
-import { Skeleton } from "@/components/ui/skeleton";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
+import { queryKeys } from "@/lib/query-keys";
+import type { ProjectListItem } from "@/server/queries/projects";
+
+const fetchProjects = async (): Promise<ProjectListItem[]> => {
+  const res = await fetch("/api/projects");
+  if (!res.ok) throw new Error("Failed to fetch projects");
+  return res.json();
+};
 
 export const Projects = () => {
   const sectionRef = useRef<HTMLElement>(null);
@@ -12,84 +21,10 @@ export const Projects = () => {
     rootMargin: "100px",
   });
 
-  const [projects, setProjects] = useState<
-    Array<{
-      slug: string;
-      title: string;
-      description: string;
-      image: string;
-    }>
-  >([]);
-  const [loading, setLoading] = useState(true);
-  const [hasStartedFetching, setHasStartedFetching] = useState(false);
-
-  useEffect(() => {
-    // Only fetch when section becomes visible and hasn't fetched yet
-    if (!isVisible || hasStartedFetching) return;
-
-    setHasStartedFetching(true);
-
-    async function fetchProjects() {
-      try {
-        const response = await fetch("/api/projects");
-        const data = await response.json();
-        setProjects(data);
-      } catch (error) {
-        console.error("Failed to fetch projects:", error);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchProjects();
-  }, [isVisible, hasStartedFetching]);
-
-  if (loading) {
-    return (
-      <section
-        ref={sectionRef}
-        id="projects"
-        className={`relative max-w-6xl flex flex-col justify-center items-center py-16 px-6 mx-auto transition-all duration-[800ms] ease-out will-change-transform ${
-          isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
-        }`}
-      >
-        {/* Floating Blobs */}
-        <div className="absolute inset-0 overflow-hidden pointer-events-none z-10">
-          <div className="absolute top-1/8 left-1/10 w-10 h-10 rounded-full bg-[#6366f1]/40 animate-firework" />
-          <div className="absolute top-1/3 right-1/8 w-12 h-12 rounded-full bg-[#f472b6]/70 animate-firework delay-300" />
-          <div className="absolute bottom-1/10 left-1/8 w-12 h-12 rounded-full bg-[#f97316]/70 animate-firework delay-500" />
-        </div>
-
-        <div className="flex flex-col items-center space-y-8 w-full md:w-screen relative z-20">
-          {/* Title skeleton */}
-          <Skeleton className="h-12 w-40" />
-
-          {/* Project Grid skeletons */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 w-2/3 relative z-10 items-stretch">
-            {[1, 2, 3, 4].map((i) => (
-              <div key={i} className="flex flex-col h-full">
-                <div className="border border-border/50 rounded-2xl overflow-hidden flex flex-col h-full">
-                  <Skeleton className="w-full h-52" />
-                  <div className="p-5 space-y-3 flex-1 flex flex-col">
-                    <div className="h-px w-full bg-border/50" />
-                    <Skeleton className="h-7 w-4/5" />
-                    <div className="space-y-2 flex-1">
-                      <Skeleton className="h-4 w-full" />
-                      <Skeleton className="h-4 w-full" />
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <Skeleton className="h-4 w-24" />
-                      <Skeleton className="h-4 w-4" />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-    );
-  }
+  const { data: projects = [] } = useQuery({
+    queryKey: queryKeys.projects,
+    queryFn: fetchProjects,
+  });
 
   return (
     <section
@@ -107,14 +42,12 @@ export const Projects = () => {
       </div>
 
       <div className="flex flex-col items-center space-y-8 w-full relative z-20">
-        {/* Title */}
         <h2 className="font-heading text-3xl md:text-5xl font-bold text-foreground">
           <span className="bg-gradient-to-r from-accent to-primary bg-clip-text text-transparent">
             Projects{" "}
           </span>
         </h2>
 
-        {/* Project Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8 w-2/3 relative z-10 items-stretch">
           {projects.map((project, index) => (
             <div

--- a/apps/web/src/components/sections/skills.tsx
+++ b/apps/web/src/components/sections/skills.tsx
@@ -1,33 +1,42 @@
 "use client";
 
-import React, { Suspense, useState, useMemo, useEffect, useRef } from "react";
+import React, { Suspense, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
 import * as THREE from "three";
 import { Canvas } from "@react-three/fiber";
 import { useGLTF, OrbitControls } from "@react-three/drei";
 
 import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
 import { useThemeContext } from "@/app/providers/ThemeProvider";
 import { skillCategoryColors } from "@/constants/colors";
 import { Skill } from "@/types";
 import { SkillCard } from "@/components/molecules/SkillCard";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
+import { queryKeys } from "@/lib/query-keys";
 
-const SkillModel = ({
-  skill,
-  theme,
-}: {
-  skill: Skill;
-  theme: string;
-}) => {
+const SKILL_CATEGORIES = [
+  "All",
+  "Frontend",
+  "Backend",
+  "DevOps",
+  "Database",
+  "Project Management",
+] as const;
+
+const fetchSkills = async (): Promise<Skill[]> => {
+  const res = await fetch("/api/skills");
+  if (!res.ok) throw new Error("Failed to fetch skills");
+  return res.json();
+};
+
+const SkillModel = ({ skill, theme }: { skill: Skill; theme: string }) => {
   const glb = useGLTF(skill.model);
 
-  // Calculate bounding box to normalize model size
   const box = new THREE.Box3().setFromObject(glb.scene);
   const size = box.getSize(new THREE.Vector3());
   const maxDimension = Math.max(size.x, size.y, size.z);
-  const targetSize = 2.5; // Target size for all models
+  const targetSize = 2.5;
   const scale = maxDimension > 0 ? targetSize / maxDimension : 1.2;
 
   glb.scene.traverse((child: THREE.Object3D) => {
@@ -59,103 +68,32 @@ export const Skills = () => {
     rootMargin: "100px",
   });
 
-  const [skills, setSkills] = useState<Skill[]>([]);
-  const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
-  const [filter, setFilter] = useState("All");
-  const [loading, setLoading] = useState(true);
-  const [hasStartedFetching, setHasStartedFetching] = useState(false);
+  const { data: skills = [] } = useQuery({
+    queryKey: queryKeys.skills,
+    queryFn: fetchSkills,
+  });
+
+  const [filter, setFilter] = useState<(typeof SKILL_CATEGORIES)[number]>("All");
   const [animatingKey, setAnimatingKey] = useState(0);
-
-  useEffect(() => {
-    // Only fetch when section becomes visible and hasn't fetched yet
-    if (!isVisible || hasStartedFetching) return;
-
-    setHasStartedFetching(true);
-
-    async function fetchSkills() {
-      try {
-        const response = await fetch("/api/skills");
-        const data = await response.json();
-
-        setSkills(data);
-
-        // Set first skill as selected initially
-        if (data.length > 0) {
-          setSelectedSkill(data[0]);
-        }
-      } catch (error) {
-        console.error("Failed to fetch skills:", error);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchSkills();
-  }, [isVisible, hasStartedFetching]);
+  const [explicitSelected, setExplicitSelected] = useState<Skill | null>(null);
 
   const filteredSkills = useMemo(
-    () =>
-      filter === "All" ? skills : skills.filter((s) => s.category === filter),
+    () => (filter === "All" ? skills : skills.filter((s) => s.category === filter)),
     [filter, skills]
   );
 
-  const handleFilterChange = (newFilter: string) => {
+  // Selected skill defaults to the first item in the current filter when the
+  // user hasn't picked anything explicitly. Avoids the previous useEffect race.
+  const selectedSkill: Skill | null =
+    explicitSelected ?? filteredSkills[0] ?? null;
+
+  const handleFilterChange = (newFilter: (typeof SKILL_CATEGORIES)[number]) => {
     setFilter(newFilter);
+    setExplicitSelected(null);
     setAnimatingKey((prev) => prev + 1);
-
-    // Auto-select first skill of the new category
-    const newFilteredSkills =
-      newFilter === "All"
-        ? skills
-        : skills.filter((s) => s.category === newFilter);
-
-    if (newFilteredSkills.length > 0) {
-      setSelectedSkill(newFilteredSkills[0]);
-    }
   };
 
-  if (loading || !selectedSkill) {
-    return (
-      <section
-        ref={sectionRef}
-        id="skills"
-        className={`max-w-6xl px-4 md:px-6 py-2 relative overflow-hidden space-y-8 !mx-auto transition-all duration-1000 ease-out ${
-          isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
-        }`}
-      >
-        {/* Header skeleton */}
-        <div className="relative text-center">
-          <Skeleton className="h-12 w-48 mx-auto mb-4" />
-          <Skeleton className="h-6 w-64 mx-auto mb-3" />
-          <Skeleton className="h-1 w-24 mx-auto rounded-full" />
-        </div>
-
-        <div className="flex flex-col !justify-center md:grid md:grid-cols-2 gap-6 md:gap-8 items-center mx-auto">
-          {/* Left Side - 3D Viewer skeleton */}
-          <div className="flex-1 h-[50vh] md:h-[calc(100dvh-12rem)] relative rounded-xl">
-            <Skeleton className="w-full h-full" />
-          </div>
-
-          {/* Right Side - Filter + Cards skeleton */}
-          <div className="flex-1 flex flex-col justify-center gap-4">
-            {/* Filter skeletons */}
-            <div className="flex gap-2 mb-2 flex-wrap justify-start">
-              {["All", "Frontend", "Backend", "DevOps", "Database", "Project Management"].map((_, i) => (
-                <Skeleton key={i} className="h-8 w-20 rounded-full" />
-              ))}
-            </div>
-
-            {/* Cards skeletons */}
-            <div className="grid grid-cols-2 xl:grid-cols-3 gap-4 pr-0 md:pr-2 items-start">
-              {[1, 2, 3, 4, 5, 6].map((i) => (
-                <Skeleton key={i} className="h-24 rounded-lg" />
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-    );
-  }
+  if (!selectedSkill) return null;
 
   return (
     <section
@@ -165,7 +103,6 @@ export const Skills = () => {
         isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
       }`}
     >
-      {/* Header */}
       <div className="relative text-center">
         <h2 className="font-heading text-3xl md:text-5xl font-bold text-foreground mb-4">
           <span className="bg-gradient-to-r from-accent to-primary bg-clip-text text-transparent">
@@ -173,14 +110,13 @@ export const Skills = () => {
           </span>
         </h2>
         <p className="text-muted-foreground max-w-2xl mx-auto text-base md:text-lg">
-          Explore <span className="text-accent font-semibold">3D orbit</span> of
-          skills and browse through categorized cards{" "}
+          Explore <span className="text-accent font-semibold">3D orbit</span> of skills
+          and browse through categorized cards{" "}
         </p>
         <div className="mt-3 w-24 h-1 bg-gradient-to-r from-accent to-primary mx-auto rounded-full" />
       </div>
 
       <div className="flex flex-col !justify-center md:grid md:grid-cols-2 gap-6 md:gap-8 items-center mx-auto">
-        {/* Left Side - 3D Viewer - Always centered */}
         <div className="flex-1 h-[50vh] md:h-[calc(100dvh-12rem)] relative rounded-xl flex items-center justify-center">
           <div className="w-full h-[300px] lg:h-full transition-all duration-500 ease-in-out animate-fadeIn">
             <Canvas camera={{ position: [0, 0, 12], fov: 60 }}>
@@ -197,11 +133,9 @@ export const Skills = () => {
           </div>
         </div>
 
-        {/* Right Side - Filter + Cards - Aligned to start */}
         <div className="flex-1 flex flex-col gap-4">
-          {/* Filter */}
           <div className="flex gap-2 mb-2 flex-wrap justify-start">
-            {["All", "Frontend", "Backend", "DevOps", "Database", "Project Management"].map((cat) => (
+            {SKILL_CATEGORIES.map((cat) => (
               <Button
                 key={cat}
                 onClick={() => handleFilterChange(cat)}
@@ -219,13 +153,12 @@ export const Skills = () => {
             ))}
           </div>
 
-          {/* Cards */}
           <div
             key={animatingKey}
             className="grid grid-cols-2 xl:grid-cols-3 gap-4 pr-0 md:pr-2 items-start"
           >
             {filteredSkills.map((skill, index) => {
-              const isActive = selectedSkill?.name === skill.name;
+              const isActive = selectedSkill.name === skill.name;
               const colorClasses =
                 skillCategoryColors[skill.category][theme as "light" | "dark"];
 
@@ -242,7 +175,7 @@ export const Skills = () => {
                     skill={skill}
                     isActive={isActive}
                     colorClasses={colorClasses}
-                    onClick={() => setSelectedSkill(skill)}
+                    onClick={() => setExplicitSelected(skill)}
                   />
                 </div>
               );

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -1,0 +1,23 @@
+import { QueryClient, isServer, defaultShouldDehydrateQuery } from "@tanstack/react-query";
+
+const makeQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+        refetchOnWindowFocus: false,
+      },
+      dehydrate: {
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) || query.state.status === "pending",
+      },
+    },
+  });
+
+let browserQueryClient: QueryClient | undefined;
+
+export const getQueryClient = () => {
+  if (isServer) return makeQueryClient();
+  if (!browserQueryClient) browserQueryClient = makeQueryClient();
+  return browserQueryClient;
+};

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -1,0 +1,10 @@
+// Single source of truth for TanStack Query cache keys.
+// Keep keys typed-as-tuple (`as const`) so useQuery infers the right shape.
+
+export const queryKeys = {
+  about: ["about"] as const,
+  projects: ["projects"] as const,
+  projectBySlug: (slug: string) => ["projects", slug] as const,
+  experiences: ["experiences"] as const,
+  skills: ["skills"] as const,
+} as const;

--- a/apps/web/src/server/queries/about.ts
+++ b/apps/web/src/server/queries/about.ts
@@ -1,0 +1,80 @@
+import "server-only";
+import { prisma } from "@/lib/prisma";
+import type { Club } from "@/types";
+
+export type AboutSectionDto = {
+  id: string;
+  key: string;
+  title: string | null;
+  content: string;
+};
+
+export type CvInfoDto = {
+  id: string;
+  title: string;
+  previewImage: string;
+  downloadPath: string;
+};
+
+export type TechStackDto = {
+  id: string;
+  name: string;
+  src: string;
+  order: number;
+};
+
+export type SocialLinkDto = {
+  id: string;
+  platform: string;
+  url: string;
+  label: string;
+  iconName: string;
+  order: number;
+};
+
+export type LoveDto = {
+  id: string;
+  mainName: string;
+  mainSrc: string;
+  clubs: Club[];
+  order: number;
+};
+
+export type AboutBundle = {
+  aboutSections: AboutSectionDto[];
+  cvInfo: CvInfoDto | null;
+  techStacks: TechStackDto[];
+  socialLinks: SocialLinkDto[];
+  loves: LoveDto[];
+};
+
+export const getAbout = async (): Promise<AboutBundle> => {
+  const [aboutSections, cvInfo, techStacks, socialLinks, loves] =
+    await Promise.all([
+      prisma.aboutSection.findMany(),
+      prisma.cvInfo.findFirst(),
+      prisma.techStack.findMany({ orderBy: { order: "asc" } }),
+      prisma.socialLink.findMany({ orderBy: { order: "asc" } }),
+      prisma.love.findMany({ orderBy: { order: "asc" } }),
+    ]);
+
+  // Prisma 6 returns Json columns as parsed objects; the string fallback is for legacy rows.
+  const lovesNormalized: LoveDto[] = loves.map((love) => ({
+    id: love.id,
+    mainName: love.mainName,
+    mainSrc: love.mainSrc,
+    order: love.order,
+    clubs:
+      typeof love.clubs === "string"
+        ? (JSON.parse(love.clubs) as Club[])
+        : (love.clubs as unknown as Club[]),
+  }));
+
+  return {
+    aboutSections,
+    cvInfo,
+    techStacks,
+    socialLinks,
+    loves: lovesNormalized,
+  };
+};

--- a/apps/web/src/server/queries/experiences.ts
+++ b/apps/web/src/server/queries/experiences.ts
@@ -1,0 +1,25 @@
+import "server-only";
+import { prisma } from "@/lib/prisma";
+
+export type ExperienceDto = {
+  id: string;
+  company: string;
+  companyLogo: string;
+  title: string;
+  location: string;
+  period: string;
+  current: boolean;
+  description: string;
+  responsibilities: string[];
+  projects: string[];
+  techStack: string;
+  employmentType: string;
+  isPublished: boolean;
+  order: number;
+};
+
+export const getExperiences = (): Promise<ExperienceDto[]> =>
+  prisma.experience.findMany({
+    where: { isPublished: true },
+    orderBy: { order: "asc" },
+  });

--- a/apps/web/src/server/queries/projects.ts
+++ b/apps/web/src/server/queries/projects.ts
@@ -1,0 +1,36 @@
+import "server-only";
+import { prisma } from "@/lib/prisma";
+
+export type ProjectListItem = {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  image: string;
+};
+
+export const getProjects = (): Promise<ProjectListItem[]> =>
+  prisma.project.findMany({
+    where: { isPublished: true },
+    select: {
+      id: true,
+      slug: true,
+      title: true,
+      description: true,
+      image: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+export const getProjectBySlug = (slug: string) =>
+  prisma.project.findUnique({
+    where: { slug },
+    include: {
+      highlights: {
+        orderBy: { order: "asc" },
+        include: {
+          images: { orderBy: { order: "asc" } },
+        },
+      },
+    },
+  });

--- a/apps/web/src/server/queries/skills.ts
+++ b/apps/web/src/server/queries/skills.ts
@@ -1,0 +1,6 @@
+import "server-only";
+import { prisma } from "@/lib/prisma";
+import type { Skill } from "@/types";
+
+export const getSkills = (): Promise<Skill[]> =>
+  prisma.skill.findMany({ orderBy: { order: "asc" } }) as unknown as Promise<Skill[]>;


### PR DESCRIPTION
## Summary

Phase 3 of repo overhaul. Replaces the legacy *useState + useEffect + fetch (gated on intersection)* pattern in every section with the canonical Next.js 15 App Router data idiom:

> **Server components prefetch via Prisma → dehydrated cache hydrates into TanStack Query on the client.**

> **Stacked on #42 → #41 → development.** Merge in order.

## UX impact

| Before                                              | After                                               |
| --------------------------------------------------- | --------------------------------------------------- |
| Skeleton flashes on every section after scroll      | Fully-rendered content on first paint               |
| Each section fires its own /api/* request           | Server prefetches all four queries in parallel      |
| /api routes + RSC each have their own Prisma calls  | Single source of truth in `src/server/queries/*`    |
| No client-side cache                                | TanStack Query cache, refetch + invalidate ready    |

## Architecture

### New layout

```
src/server/queries/
├── about.ts          ← getAbout()       — bundled (sections + cv + tech + social + loves)
├── experiences.ts    ← getExperiences() — published, ordered
├── projects.ts       ← getProjects() + getProjectBySlug(slug)
└── skills.ts         ← getSkills()      — ordered

src/lib/
├── query-keys.ts     ← central registry: queryKeys.about / .projects / .experiences / .skills / .projectBySlug(slug)
└── query-client.ts   ← getQueryClient() — fresh per request on server, singleton on client

src/app/providers/QueryProvider.tsx   ← client wrapper, includes ReactQueryDevtools (dev only)
```

### Wiring

- `src/app/layout.tsx` wraps children with `QueryProvider` (outside `ThemeProvider` so theme consumers can also call `useQuery`).
- `src/app/page.tsx` is now `async` — prefetches all four queries in parallel, dehydrates into `<HydrationBoundary>`.
- All 5 API routes (`/api/{about,experiences,projects,projects/[slug],skills}`) reduced to thin wrappers that call the corresponding `server/queries/*` function.

### Section refactors

| File                                | LOC before | LOC after | Notes                                                     |
| ----------------------------------- | ---------- | --------- | --------------------------------------------------------- |
| `sections/projects.tsx`             | 134        | 60        | Single useQuery, no loading branch.                       |
| `sections/experiences.tsx`          | 187        | 95        | Mapping moved to memoised pure function.                  |
| `sections/skills.tsx`               | 255        | 175       | Removed useEffect-based selectedSkill init race.          |
| `sections/about.tsx`                | 472        | 295       | Replaced 200+ lines of mapping useEffects with `useMemo`. |
| `app/projects/[slug]/page.tsx`      | 115        | 65        | Uses server query helper instead of inline Prisma.        |

## Test plan

- [x] `npm run lint` — clean.
- [x] `next build` — *Compiled successfully* + type-check pass. Prerender step still needs DB connectivity for `generateStaticParams`; that constraint pre-dates this PR.
- [ ] Smoke-test in `npm run dev` against active Neon DB:
  - [ ] All sections render content immediately (no skeleton flash).
  - [ ] Network tab: `/api/*` requests do **not** fire on initial load.
  - [ ] Skill filter, experience expand, social hover, CV download still work.
  - [ ] Theme toggle still works.
- [ ] React Query Devtools button appears bottom-right in dev mode.