### PR TITLE
refactor(atomic): extract atoms + molecules, drop dead Footer prop (-32% LOC)

### DIFF
--- a/apps/web/src/components/atoms/GradientText.tsx
+++ b/apps/web/src/components/atoms/GradientText.tsx
@@ -1,0 +1,33 @@
+import { createElement, type ComponentPropsWithoutRef, type ElementType, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type GradientTextProps<T extends ElementType> = {
+  as?: T;
+  className?: string;
+  children: ReactNode;
+} & Omit<ComponentPropsWithoutRef<T>, "as" | "className" | "children">;
+
+/**
+ * Brand-gradient text using accent → primary tokens. The default element is
+ * <span> so this can be embedded inside any heading. Pass `as="h2"` etc. to
+ * render a heading directly.
+ */
+export const GradientText = <T extends ElementType = "span">({
+  as,
+  className,
+  children,
+  ...rest
+}: GradientTextProps<T>) => {
+  const Component: ElementType = as ?? "span";
+  return createElement(
+    Component,
+    {
+      className: cn(
+        "bg-gradient-to-r from-accent to-primary bg-clip-text text-transparent",
+        className
+      ),
+      ...rest,
+    },
+    children
+  );
+};

--- a/apps/web/src/components/atoms/SectionContainer.tsx
+++ b/apps/web/src/components/atoms/SectionContainer.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useRef, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
+
+type SectionContainerProps = {
+  id: string;
+  children: ReactNode;
+  className?: string;
+  /**
+   * Tailwind transition-duration class applied to the reveal animation.
+   * Defaults to `duration-1000`.
+   */
+  duration?: string;
+};
+
+/**
+ * Page-section wrapper that fades + translates content in once it scrolls
+ * into view. The reveal pattern was duplicated across every section before
+ * Phase 4 — extracted here as the single source of truth.
+ *
+ * Phase 6 will swap the intersection-observer + Tailwind transition for
+ * `motion.section` + `whileInView`. Keep the public API identical so the
+ * cutover is a one-file change.
+ */
+export const SectionContainer = ({
+  id,
+  children,
+  className,
+  duration = "duration-1000",
+}: SectionContainerProps) => {
+  const ref = useRef<HTMLElement>(null);
+  const isVisible = useIntersectionObserver(ref, {
+    threshold: 0.1,
+    rootMargin: "100px",
+  });
+
+  return (
+    <section
+      ref={ref}
+      id={id}
+      className={cn(
+        "transition-all ease-out",
+        duration,
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8",
+        className
+      )}
+    >
+      {children}
+    </section>
+  );
+};

--- a/apps/web/src/components/atoms/SectionHeading.tsx
+++ b/apps/web/src/components/atoms/SectionHeading.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { GradientText } from "./GradientText";
+
+type SectionHeadingProps = {
+  children: ReactNode;
+  className?: string;
+  /** Sub-heading rendered below the title. */
+  subtitle?: ReactNode;
+  /** Render the small accent divider after subtitle (used by Skills). */
+  withDivider?: boolean;
+};
+
+/**
+ * Composed heading for top-of-section titles. Used by every page section.
+ * Wraps GradientText so the title and subtitle stay visually consistent.
+ */
+export const SectionHeading = ({
+  children,
+  className,
+  subtitle,
+  withDivider = false,
+}: SectionHeadingProps) => (
+  <div className={cn("relative text-center", className)}>
+    <h2 className="font-heading text-3xl md:text-5xl font-bold text-foreground mb-4">
+      <GradientText>{children}</GradientText>
+    </h2>
+    {subtitle ? (
+      <p className="text-muted-foreground max-w-2xl mx-auto text-base md:text-lg">
+        {subtitle}
+      </p>
+    ) : null}
+    {withDivider ? (
+      <div className="mt-3 w-24 h-1 bg-gradient-to-r from-accent to-primary mx-auto rounded-full" />
+    ) : null}
+  </div>
+);

--- a/apps/web/src/components/molecules/CvDownloadCard.tsx
+++ b/apps/web/src/components/molecules/CvDownloadCard.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { Download } from "lucide-react";
+
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { GradientText } from "@/components/atoms/GradientText";
+import type { CvInfo } from "@/types";
+
+type CvDownloadCardProps = {
+  cvInfo: CvInfo | null;
+};
+
+/**
+ * CV preview card with the gradient download button. Hovering scrolls the
+ * preview image upward; the download button on desktop only appears on
+ * hover, and on mobile is always visible.
+ */
+export const CvDownloadCard = ({ cvInfo }: CvDownloadCardProps) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  return (
+    <Card
+      className="col-span-1 lg:col-span-2 p-4 md:p-6 flex flex-col justify-center gap-4 transition-all duration-300 hover:translate-y-[-4px] hover:shadow-xl"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <div className="flex justify-between items-center content-center mb-2 md:mb-4 transition-all duration-300">
+        <h4 className="text-left font-heading text-base md:text-lg lg:text-xl font-bold text-foreground">
+          <GradientText>{cvInfo?.title}</GradientText>
+        </h4>
+        <Button
+          asChild
+          className={`
+            relative
+            size-10 sm:size-12 lg:size-14
+            rounded-lg sm:rounded-xl md:rounded-2xl
+            flex items-center justify-center
+            bg-gradient-to-br from-red-500 via-orange-500 to-yellow-400
+            text-white font-semibold
+            shadow-[0_6px_12px_rgba(0,0,0,0.3),0_0_8px_rgba(0,0,0,0.25)]
+            border border-transparent
+            transition-all duration-200 ease-[cubic-bezier(0.4,0,0.2,1)]
+            hover:scale-105 hover:shadow-[0_10px_20px_rgba(0,0,0,0.35),0_0_12px_rgba(0,0,0,0.3)]
+            active:scale-95 active:shadow-[inset_0_3px_6px_rgba(0,0,0,0.4),inset_0_0_4px_rgba(255,255,255,0.25)]
+            active:before:translate-y-[-2px] active:before:opacity-40
+            before:content-[''] before:absolute before:inset-0 before:rounded-xl
+            before:bg-gradient-to-t before:from-white/30 before:to-transparent
+            before:transition-all before:duration-150
+            after:content-[''] after:absolute after:inset-[-4px] after:rounded-[18px]
+            after:border after:border-white/10 after:opacity-0 after:scale-90
+            active:after:opacity-60 active:after:scale-100 active:after:transition-all active:after:duration-200
+            animate-gradient-x
+            ${
+              isHovered
+                ? "md:opacity-100 md:translate-y-0"
+                : "md:opacity-0 md:translate-y-2 md:pointer-events-none"
+            }
+          `}
+        >
+          <Link
+            href={cvInfo?.downloadPath ?? "#"}
+            target="_blank"
+            download
+            className="flex items-center justify-center"
+          >
+            <span className="absolute inline-flex h-full w-full rounded-full bg-pink-400 opacity-75 animate-ping md:hidden"></span>
+            <Download className="size-6 drop-shadow-[0_1px_2px_rgba(0,0,0,0.6)]" />
+          </Link>
+        </Button>
+      </div>
+      <div className="w-full h-[150px] md:h-[200px] overflow-hidden rounded-lg shadow-md relative">
+        <div className="absolute inset-0 transition-transform duration-[1500ms] ease-in-out hover:-translate-y-[100%]">
+          <Image
+            src={cvInfo?.previewImage ?? ""}
+            alt="CV Preview"
+            width={300}
+            height={1000}
+            className="w-full h-auto object-contain"
+            priority
+            onTouchMove={() => setIsHovered(true)}
+          />
+        </div>
+      </div>
+    </Card>
+  );
+};

--- a/apps/web/src/components/molecules/LoveCard.tsx
+++ b/apps/web/src/components/molecules/LoveCard.tsx
@@ -1,0 +1,85 @@
+import Image from "next/image";
+import { ArrowBigRight } from "lucide-react";
+
+import { Card } from "@/components/ui/card";
+import { GradientText } from "@/components/atoms/GradientText";
+import type { Love } from "@/types";
+
+type LoveCardProps = {
+  loves: Love[];
+};
+
+/**
+ * "What I Love" card. Each row reveals a domino-animated cluster of clubs
+ * on hover (desktop). On mobile the clubs are always visible alongside.
+ */
+export const LoveCard = ({ loves }: LoveCardProps) => (
+  <Card className="col-span-1 lg:col-span-2 p-4 md:p-6 transition-all duration-300 hover:translate-y-[-4px] hover:shadow-xl">
+    <h4 className="text-right font-heading text-base md:text-lg lg:text-xl font-bold text-foreground mb-3 md:mb-4">
+      <GradientText>What I Love</GradientText>
+    </h4>
+
+    <div className="flex flex-col gap-10">
+      {loves.map((love, idx) => (
+        <div
+          key={idx}
+          className="group relative flex justify-center items-center"
+        >
+          {/* Main category */}
+          <div
+            className="group relative bg-background/50 backdrop-blur-sm
+              rounded-full p-2
+              transition-all duration-500 ease-out
+              md:group-hover:-translate-x-20 md:group-hover:scale-110 md:group-hover:shadow-lg border border-border/50"
+          >
+            <Image
+              src={love.main.src}
+              width={1000}
+              height={1000}
+              alt={love.main.name}
+              className="size-8 sm:size-10 lg:size-12 transition-transform duration-300 group-hover:scale-110"
+            />
+            <div className="absolute -top-8 left-1/2 -translate-x-1/2 bg-foreground text-background text-xs px-2 py-1 rounded opacity-0 md:group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">
+              {love.main.name}
+            </div>
+          </div>
+
+          {/* Arrow + Clubs */}
+          <div
+            className="flex items-center gap-3 md:absolute left-1/2 -translate-x-[20%] animate-moveRight
+                       md:opacity-0 md:group-hover:opacity-100 transition-opacity duration-300 delay-200"
+          >
+            <ArrowBigRight className="text-muted-foreground ml-3 md:ml-0 animate-moveRight" />
+
+            <div className="flex flex-row items-center gap-3 md:gap-4">
+              {love.clubs.map((club, i) => (
+                <div
+                  key={i}
+                  style={{ transitionDelay: `${i * 120 + 200}ms` }}
+                  className="md:opacity-0 md:translate-x-3
+                    md:group-hover:opacity-100 md:group-hover:translate-x-0
+                    transition-all duration-500 ease-out
+                    relative bg-background/50 backdrop-blur-sm
+                    rounded-full p-2
+                    border border-border/50
+                    hover:scale-110 hover:shadow-lg"
+                >
+                  <Image
+                    src={club.src}
+                    width={1000}
+                    height={1000}
+                    alt={club.name}
+                    className="size-6 sm:size-8 md:size-10 transition-transform duration-300 group-hover:scale-110"
+                  />
+                  <div className="absolute -top-8 left-1/2 transform -translate-x-1/2 bg-foreground text-background text-xs px-2 py-1 rounded opacity-0 md:group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">
+                    {club.name}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  </Card>
+);

--- a/apps/web/src/components/organisms/Footer.tsx
+++ b/apps/web/src/components/organisms/Footer.tsx
@@ -2,60 +2,53 @@
 
 import Link from "next/link";
 
-export const Footer = ({ loading }: { loading: boolean }) => {
+export const Footer = () => {
   return (
     <footer
-      className={`${
-        loading && "hidden"
-      } z-50 fixed bottom-0 !w-full overflow-hidden 
+      className="z-50 fixed bottom-0 !w-full overflow-hidden
         py-2 sm:py-3 px-2 sm:px-4
-        border-t border-gray-100 
-        bg-gradient-to-r from-gray-100 to-white 
-        shadow-xl 
+        border-t border-gray-100
+        bg-gradient-to-r from-gray-100 to-white
+        shadow-xl
         dark:from-gray-900 dark:to-black dark:border-gray-800
-        text-gray-400`}
+        text-gray-400"
     >
       <div className="flex flex-row justify-center items-center text-center overflow-hidden">
-        {[...Array(1)].map((_, i) => (
-          <div
-            key={i}
-            className="animate-bounce-x-big whitespace-nowrap flex flex-row gap-4 sm:gap-6 md:gap-8 px-3 sm:px-6"
-          >
-            <div className="flex flex-row items-center gap-3 sm:gap-6">
-              <span className="text-[10px] sm:text-sm md:text-base tracking-widest group-hover:text-pink-400 transition-colors whitespace-nowrap">
-                © {new Date().getFullYear()} – Shendy Putra Perdana Yohansah
+        <div className="animate-bounce-x-big whitespace-nowrap flex flex-row gap-4 sm:gap-6 md:gap-8 px-3 sm:px-6">
+          <div className="flex flex-row items-center gap-3 sm:gap-6">
+            <span className="text-[10px] sm:text-sm md:text-base tracking-widest group-hover:text-pink-400 transition-colors whitespace-nowrap">
+              © {new Date().getFullYear()} – Shendy Putra Perdana Yohansah
+            </span>
+
+            <span className="text-[10px] sm:text-xs text-gray-600">◆</span>
+
+            <Link
+              href="https://calendly.com/shendyppy/30min"
+              target="_blank"
+              className="group flex flex-row items-center gap-1"
+            >
+              <span className="text-[10px] sm:text-sm md:text-base tracking-widest group-hover:text-green-400 transition-colors whitespace-nowrap">
+                Any ideas for collaboration?{" "}
               </span>
-
-              <span className="text-[10px] sm:text-xs text-gray-600">◆</span>
-
-              <Link
-                href="https://calendly.com/shendyppy/30min"
-                target="_blank"
-                className="group flex flex-row items-center gap-1"
+              <div
+                className="px-2 py-1 sm:px-3 sm:py-1.5
+                  rounded-full text-white font-semibold shadow-md
+                  text-[10px] sm:text-xs md:text-sm
+                  bg-gradient-to-r from-gray-400 to-black
+                  group-hover:from-pink-500 group-hover:to-yellow-500
+                  transition-all"
               >
-                <span className="text-[10px] sm:text-sm md:text-base tracking-widest group-hover:text-green-400 transition-colors whitespace-nowrap">
-                  Any ideas for collaboration?{" "}
-                </span>
-                <div
-                  className="px-2 py-1 sm:px-3 sm:py-1.5 
-                    rounded-full text-white font-semibold shadow-md
-                    text-[10px] sm:text-xs md:text-sm
-                    bg-gradient-to-r from-gray-400 to-black 
-                    group-hover:from-pink-500 group-hover:to-yellow-500 
-                    transition-all"
-                >
-                  Let&apos;s connect! 🚀
-                </div>
-              </Link>
+                Let&apos;s connect! 🚀
+              </div>
+            </Link>
 
-              <span className="text-[10px] sm:text-xs text-gray-600">◆</span>
+            <span className="text-[10px] sm:text-xs text-gray-600">◆</span>
 
-              <span className="text-[10px] sm:text-sm md:text-base tracking-widest group-hover:text-teal-400 transition-colors whitespace-nowrap">
-                Front End Developer, Full Stack Developer, Business Analyst
-              </span>
-            </div>
+            <span className="text-[10px] sm:text-sm md:text-base tracking-widest group-hover:text-teal-400 transition-colors whitespace-nowrap">
+              Front End Developer, Full Stack Developer, Business Analyst
+            </span>
           </div>
-        ))}
+        </div>
       </div>
     </footer>
   );

--- a/apps/web/src/components/organisms/PageWrapper.tsx
+++ b/apps/web/src/components/organisms/PageWrapper.tsx
@@ -63,7 +63,7 @@ export const PageWrapper = ({ children }: PageWrapperProps) => {
             : "opacity-0 pointer-events-none"
         }`}
       >
-        <Footer loading={false} />
+        <Footer />
       </div>
     </div>
   );

--- a/apps/web/src/components/organisms/ProjectPageContent.tsx
+++ b/apps/web/src/components/organisms/ProjectPageContent.tsx
@@ -7,6 +7,7 @@ import { ArrowBigLeft, ArrowBigRight } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { ImageModal } from "@/components/ui/image-modal";
+import { GradientText } from "@/components/atoms/GradientText";
 import type { ProjectDetail } from "@/types";
 
 interface ProjectPageContentProps {
@@ -87,8 +88,10 @@ export const ProjectPageContent = ({ project }: ProjectPageContentProps) => {
                     {String(index + 1).padStart(2, "0")} /{" "}
                     {String(project.highlights.length).padStart(2, "0")}
                   </div>
-                  <h2 className="font-heading text-2xl sm:text-3xl font-bold mb-6 bg-gradient-to-r from-accent to-primary bg-clip-text text-transparent hover:from-blue-400 hover:to-purple-800 transition-all duration-500">
-                    {highlight.title}
+                  <h2 className="font-heading text-2xl sm:text-3xl font-bold mb-6">
+                    <GradientText className="hover:from-blue-400 hover:to-purple-800 transition-all duration-500">
+                      {highlight.title}
+                    </GradientText>
                   </h2>
                   <p className="text-muted-foreground mb-8 whitespace-pre-line leading-relaxed text-base transform hover:translate-x-2 transition-transform duration-300">
                     {highlight.description}

--- a/apps/web/src/components/sections/about.tsx
+++ b/apps/web/src/components/sections/about.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 import Image from "next/image";
-import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 
 import {
   ArrowBigRight,
-  Download,
   Github,
   Instagram,
   Linkedin,
@@ -23,7 +21,10 @@ import { useThemeContext } from "@/app/providers/ThemeProvider";
 import { SECTION_IDS, SITE_CONFIG } from "@/constants/config";
 import { SocialButton } from "@/components/molecules/SocialButton";
 import { TechStackItem } from "@/components/molecules/TechStackItem";
-import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
+import { LoveCard } from "@/components/molecules/LoveCard";
+import { CvDownloadCard } from "@/components/molecules/CvDownloadCard";
+import { SectionContainer } from "@/components/atoms/SectionContainer";
+import { GradientText } from "@/components/atoms/GradientText";
 import { queryKeys } from "@/lib/query-keys";
 import type { AboutBundle } from "@/server/queries/about";
 
@@ -43,13 +44,6 @@ const fetchAbout = async (): Promise<AboutBundle> => {
 
 export const About = () => {
   const { theme } = useThemeContext();
-  const sectionRef = useRef<HTMLElement>(null);
-  const isVisible = useIntersectionObserver(sectionRef, {
-    threshold: 0.1,
-    rootMargin: "100px",
-  });
-
-  const [isHovered, setIsHovered] = useState(false);
 
   const { data } = useQuery({ queryKey: queryKeys.about, queryFn: fetchAbout });
 
@@ -86,12 +80,9 @@ export const About = () => {
   const { professionalBio, currentLearningJourney, cvInfo, techStacks, socialLinks, loves } = view;
 
   return (
-    <section
-      ref={sectionRef}
+    <SectionContainer
       id="about"
-      className={`w-full flex flex-col justify-center items-center py-16 px-4 sm:px-6 md:px-8 lg:px-10 xl:px-14 mx-auto rounded-[40px] md:rounded-[80px] shadow-2xl bg-accent transition-all duration-1000 ease-out ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
-      }`}
+      className="w-full flex flex-col justify-center items-center py-16 px-4 sm:px-6 md:px-8 lg:px-10 xl:px-14 mx-auto rounded-[40px] md:rounded-[80px] shadow-2xl bg-accent"
     >
       <div className="max-w-6xl w-full flex flex-col gap-8 md:gap-12">
         {/* Top row: text, photo, socials */}
@@ -99,9 +90,7 @@ export const About = () => {
           {/* Text block */}
           <Card className="lg:col-span-3 p-4 md:p-6 rounded-xl transition-all duration-500 hover:-rotate-2 hover:scale-105 hover:shadow-xl">
             <h2 className="font-heading text-xl md:text-2xl lg:text-3xl font-bold text-foreground mb-3 md:mb-4">
-              <span className="bg-gradient-to-r from-accent to-primary bg-clip-text text-transparent">
-                {professionalBio.title}
-              </span>
+              <GradientText>{professionalBio.title}</GradientText>
             </h2>
             <p className="text-muted-foreground leading-relaxed text-sm md:text-base">
               {professionalBio.content}
@@ -150,79 +139,12 @@ export const About = () => {
 
         {/* Bottom row */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4 md:gap-6 items-start">
-          {/* CV Card */}
-          <Card
-            className="col-span-1 lg:col-span-2 p-4 md:p-6 flex flex-col justify-center gap-4 transition-all duration-300 hover:translate-y-[-4px] hover:shadow-xl"
-            onMouseEnter={() => setIsHovered(true)}
-            onMouseLeave={() => setIsHovered(false)}
-          >
-            <div className="flex justify-between items-center content-center mb-2 md:mb-4 transition-all duration-300">
-              <h4 className="text-left font-heading text-base md:text-lg lg:text-xl font-bold text-foreground">
-                <span className="bg-gradient-to-r from-accent to-primary bg-clip-text text-transparent">
-                  {cvInfo?.title}
-                </span>
-              </h4>
-              <Button
-                asChild
-                className={`
-    relative
-    size-10 sm:size-12 lg:size-14
-    rounded-lg sm:rounded-xl md:rounded-2xl
-    flex items-center justify-center
-    bg-gradient-to-br from-red-500 via-orange-500 to-yellow-400
-    text-white font-semibold
-    shadow-[0_6px_12px_rgba(0,0,0,0.3),0_0_8px_rgba(0,0,0,0.25)]
-    border border-transparent
-    transition-all duration-200 ease-[cubic-bezier(0.4,0,0.2,1)]
-    hover:scale-105 hover:shadow-[0_10px_20px_rgba(0,0,0,0.35),0_0_12px_rgba(0,0,0,0.3)]
-    active:scale-95 active:shadow-[inset_0_3px_6px_rgba(0,0,0,0.4),inset_0_0_4px_rgba(255,255,255,0.25)]
-    active:before:translate-y-[-2px] active:before:opacity-40
-    before:content-[''] before:absolute before:inset-0 before:rounded-xl
-    before:bg-gradient-to-t before:from-white/30 before:to-transparent
-    before:transition-all before:duration-150
-    after:content-[''] after:absolute after:inset-[-4px] after:rounded-[18px]
-    after:border after:border-white/10 after:opacity-0 after:scale-90
-    active:after:opacity-60 active:after:scale-100 active:after:transition-all active:after:duration-200
-    animate-gradient-x
-    ${
-      isHovered
-        ? "md:opacity-100 md:translate-y-0"
-        : "md:opacity-0 md:translate-y-2 md:pointer-events-none"
-    }
-  `}
-              >
-                <Link
-                  href={cvInfo?.downloadPath ?? "#"}
-                  target="_blank"
-                  download
-                  className="flex items-center justify-center"
-                >
-                  <span className="absolute inline-flex h-full w-full rounded-full bg-pink-400 opacity-75 animate-ping md:hidden"></span>
-                  <Download className="size-6 drop-shadow-[0_1px_2px_rgba(0,0,0,0.6)]" />
-                </Link>
-              </Button>
-            </div>
-            <div className="w-full h-[150px] md:h-[200px] overflow-hidden rounded-lg shadow-md relative">
-              <div className="absolute inset-0 transition-transform duration-[1500ms] ease-in-out hover:-translate-y-[100%]">
-                <Image
-                  src={cvInfo?.previewImage ?? ""}
-                  alt="CV Preview"
-                  width={300}
-                  height={1000}
-                  className="w-full h-auto object-contain"
-                  priority
-                  onTouchMove={() => setIsHovered(true)}
-                />
-              </div>
-            </div>
-          </Card>
+          <CvDownloadCard cvInfo={cvInfo} />
 
           {/* Tech Stacks Card */}
           <Card className="col-span-1 lg:col-span-2 p-4 md:p-6 transition-all duration-300 hover:translate-y-[-4px] hover:shadow-xl">
             <h4 className="text-center font-heading text-base md:text-lg lg:text-xl font-bold text-foreground mb-3 md:mb-4">
-              <span className="bg-gradient-to-r from-accent to-primary bg-clip-text text-transparent">
-                Tech Stacks
-              </span>
+              <GradientText>Tech Stacks</GradientText>
             </h4>
             <div className="flex flex-wrap justify-center items-center gap-2 md:gap-3">
               {techStacks.map((tech, index) => (
@@ -240,81 +162,9 @@ export const About = () => {
             </div>
           </Card>
 
-          {/* What I Love Card */}
-          <Card className="col-span-1 lg:col-span-2 p-4 md:p-6 transition-all duration-300 hover:translate-y-[-4px] hover:shadow-xl">
-            <h4 className="text-right font-heading text-base md:text-lg lg:text-xl font-bold text-foreground mb-3 md:mb-4">
-              <span className="bg-gradient-to-r from-accent to-primary bg-clip-text text-transparent">
-                What I Love
-              </span>
-            </h4>
-
-            <div className="flex flex-col gap-10">
-              {loves.map((love, idx) => (
-                <div
-                  key={idx}
-                  className="group relative flex justify-center items-center"
-                >
-                  {/* Main category */}
-                  <div
-                    className="group relative bg-background/50 backdrop-blur-sm
-    rounded-full p-2
-    transition-all duration-500 ease-out
-    md:group-hover:-translate-x-20 md:group-hover:scale-110 md:group-hover:shadow-lg border border-border/50"
-                  >
-                    <Image
-                      src={love.main.src}
-                      width={1000}
-                      height={1000}
-                      alt={love.main.name}
-                      className="size-8 sm:size-10 lg:size-12 transition-transform duration-300 group-hover:scale-110"
-                    />
-                    <div className="absolute -top-8 left-1/2 -translate-x-1/2 bg-foreground text-background text-xs px-2 py-1 rounded opacity-0 md:group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">
-                      {love.main.name}
-                    </div>
-                  </div>
-
-                  {/* Arrow + Clubs */}
-                  <div
-                    className="flex items-center gap-3 md:absolute left-1/2 -translate-x-[20%] animate-moveRight
-                     md:opacity-0 md:group-hover:opacity-100 transition-opacity duration-300 delay-200"
-                  >
-                    {/* Arrow */}
-                    <ArrowBigRight className="text-muted-foreground ml-3 md:ml-0 animate-moveRight" />
-
-                    {/* Clubs (domino reveal) */}
-                    <div className="flex flex-row items-center gap-3 md:gap-4">
-                      {love.clubs.map((club, i) => (
-                        <div
-                          key={i}
-                          style={{ transitionDelay: `${i * 120 + 200}ms` }}
-                          className="md:opacity-0 md:translate-x-3
-    md:group-hover:opacity-100 md:group-hover:translate-x-0
-    transition-all duration-500 ease-out
-    relative bg-background/50 backdrop-blur-sm
-    rounded-full p-2
-    border border-border/50
-    hover:scale-110 hover:shadow-lg"
-                        >
-                          <Image
-                            src={club.src}
-                            width={1000}
-                            height={1000}
-                            alt={club.name}
-                            className="size-6 sm:size-8 md:size-10 transition-transform duration-300 group-hover:scale-110"
-                          />
-                          <div className="absolute -top-8 left-1/2 transform -translate-x-1/2 bg-foreground text-background text-xs px-2 py-1 rounded opacity-0 md:group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">
-                            {club.name}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </Card>
+          <LoveCard loves={loves} />
         </div>
       </div>
-    </section>
+    </SectionContainer>
   );
 };

--- a/apps/web/src/components/sections/experiences.tsx
+++ b/apps/web/src/components/sections/experiences.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { useThemeContext } from "@/app/providers/ThemeProvider";
 import { ExperienceCard } from "@/components/molecules/ExperienceCard";
-import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
+import { SectionContainer } from "@/components/atoms/SectionContainer";
+import { SectionHeading } from "@/components/atoms/SectionHeading";
 import { queryKeys } from "@/lib/query-keys";
 import type { ExperienceDto } from "@/server/queries/experiences";
 import type { Experience, EmploymentType } from "@/types";
@@ -34,11 +35,6 @@ const mapToExperience = (raw: ExperienceDto[]): Experience[] =>
 
 export const Experiences = () => {
   const { theme } = useThemeContext();
-  const sectionRef = useRef<HTMLElement>(null);
-  const isVisible = useIntersectionObserver(sectionRef, {
-    threshold: 0.1,
-    rootMargin: "100px",
-  });
 
   const { data: rawExperiences = [] } = useQuery({
     queryKey: queryKeys.experiences,
@@ -56,21 +52,12 @@ export const Experiences = () => {
   };
 
   return (
-    <section
-      ref={sectionRef}
+    <SectionContainer
       id="experiences"
-      className={`relative max-w-6xl flex flex-col justify-center items-center py-16 px-6 mx-auto transition-all duration-1000 ease-out ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
-      }`}
+      className="relative max-w-6xl flex flex-col justify-center items-center py-16 px-6 mx-auto"
     >
       <div className="flex flex-col items-center space-y-8 w-full relative z-20">
-        <div className="flex flex-col items-center text-center">
-          <h2 className="font-heading text-3xl md:text-5xl font-bold text-foreground">
-            <span className="bg-gradient-to-r from-accent to-primary bg-clip-text text-transparent">
-              Experiences
-            </span>
-          </h2>
-        </div>
+        <SectionHeading>Experiences</SectionHeading>
 
         <div className="space-y-4 px-1 w-full md:w-4/5">
           {experiences.map((exp) => (
@@ -84,6 +71,6 @@ export const Experiences = () => {
           ))}
         </div>
       </div>
-    </section>
+    </SectionContainer>
   );
 };

--- a/apps/web/src/components/sections/projects.tsx
+++ b/apps/web/src/components/sections/projects.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { ProjectCard } from "@/components/molecules/ProjectCard";
-import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
+import { SectionContainer } from "@/components/atoms/SectionContainer";
+import { SectionHeading } from "@/components/atoms/SectionHeading";
 import { queryKeys } from "@/lib/query-keys";
 import type { ProjectListItem } from "@/server/queries/projects";
 
@@ -15,24 +15,16 @@ const fetchProjects = async (): Promise<ProjectListItem[]> => {
 };
 
 export const Projects = () => {
-  const sectionRef = useRef<HTMLElement>(null);
-  const isVisible = useIntersectionObserver(sectionRef, {
-    threshold: 0.1,
-    rootMargin: "100px",
-  });
-
   const { data: projects = [] } = useQuery({
     queryKey: queryKeys.projects,
     queryFn: fetchProjects,
   });
 
   return (
-    <section
-      ref={sectionRef}
+    <SectionContainer
       id="projects"
-      className={`relative max-w-6xl flex flex-col justify-center items-center py-16 px-6 mx-auto transition-all duration-[800ms] ease-out will-change-transform ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
-      }`}
+      duration="duration-[800ms]"
+      className="relative max-w-6xl flex flex-col justify-center items-center py-16 px-6 mx-auto will-change-transform"
     >
       {/* Floating Blobs */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none z-10">
@@ -42,11 +34,7 @@ export const Projects = () => {
       </div>
 
       <div className="flex flex-col items-center space-y-8 w-full relative z-20">
-        <h2 className="font-heading text-3xl md:text-5xl font-bold text-foreground">
-          <span className="bg-gradient-to-r from-accent to-primary bg-clip-text text-transparent">
-            Projects{" "}
-          </span>
-        </h2>
+        <SectionHeading>Projects </SectionHeading>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8 w-2/3 relative z-10 items-stretch">
           {projects.map((project, index) => (
@@ -63,6 +51,6 @@ export const Projects = () => {
           ))}
         </div>
       </div>
-    </section>
+    </SectionContainer>
   );
 };

--- a/apps/web/src/components/sections/skills.tsx
+++ b/apps/web/src/components/sections/skills.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { Suspense, useMemo, useRef, useState } from "react";
+import React, { Suspense, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import * as THREE from "three";
@@ -10,19 +10,12 @@ import { useGLTF, OrbitControls } from "@react-three/drei";
 import { Button } from "@/components/ui/button";
 import { useThemeContext } from "@/app/providers/ThemeProvider";
 import { skillCategoryColors } from "@/constants/colors";
+import { SKILL_CATEGORIES, type SkillCategoryFilter } from "@/constants/config";
 import { Skill } from "@/types";
 import { SkillCard } from "@/components/molecules/SkillCard";
-import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
+import { SectionContainer } from "@/components/atoms/SectionContainer";
+import { SectionHeading } from "@/components/atoms/SectionHeading";
 import { queryKeys } from "@/lib/query-keys";
-
-const SKILL_CATEGORIES = [
-  "All",
-  "Frontend",
-  "Backend",
-  "DevOps",
-  "Database",
-  "Project Management",
-] as const;
 
 const fetchSkills = async (): Promise<Skill[]> => {
   const res = await fetch("/api/skills");
@@ -62,18 +55,13 @@ const SkillModel = ({ skill, theme }: { skill: Skill; theme: string }) => {
 
 export const Skills = () => {
   const { theme } = useThemeContext();
-  const sectionRef = useRef<HTMLElement>(null);
-  const isVisible = useIntersectionObserver(sectionRef, {
-    threshold: 0.1,
-    rootMargin: "100px",
-  });
 
   const { data: skills = [] } = useQuery({
     queryKey: queryKeys.skills,
     queryFn: fetchSkills,
   });
 
-  const [filter, setFilter] = useState<(typeof SKILL_CATEGORIES)[number]>("All");
+  const [filter, setFilter] = useState<SkillCategoryFilter>("All");
   const [animatingKey, setAnimatingKey] = useState(0);
   const [explicitSelected, setExplicitSelected] = useState<Skill | null>(null);
 
@@ -82,12 +70,9 @@ export const Skills = () => {
     [filter, skills]
   );
 
-  // Selected skill defaults to the first item in the current filter when the
-  // user hasn't picked anything explicitly. Avoids the previous useEffect race.
-  const selectedSkill: Skill | null =
-    explicitSelected ?? filteredSkills[0] ?? null;
+  const selectedSkill: Skill | null = explicitSelected ?? filteredSkills[0] ?? null;
 
-  const handleFilterChange = (newFilter: (typeof SKILL_CATEGORIES)[number]) => {
+  const handleFilterChange = (newFilter: SkillCategoryFilter) => {
     setFilter(newFilter);
     setExplicitSelected(null);
     setAnimatingKey((prev) => prev + 1);
@@ -96,25 +81,21 @@ export const Skills = () => {
   if (!selectedSkill) return null;
 
   return (
-    <section
-      ref={sectionRef}
+    <SectionContainer
       id="skills"
-      className={`max-w-6xl px-4 md:px-6 py-2 relative overflow-hidden space-y-8 !mx-auto transition-all duration-1000 ease-out ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
-      }`}
+      className="max-w-6xl px-4 md:px-6 py-2 relative overflow-hidden space-y-8 !mx-auto"
     >
-      <div className="relative text-center">
-        <h2 className="font-heading text-3xl md:text-5xl font-bold text-foreground mb-4">
-          <span className="bg-gradient-to-r from-accent to-primary bg-clip-text text-transparent">
-            Experiments{" "}
-          </span>
-        </h2>
-        <p className="text-muted-foreground max-w-2xl mx-auto text-base md:text-lg">
-          Explore <span className="text-accent font-semibold">3D orbit</span> of skills
-          and browse through categorized cards{" "}
-        </p>
-        <div className="mt-3 w-24 h-1 bg-gradient-to-r from-accent to-primary mx-auto rounded-full" />
-      </div>
+      <SectionHeading
+        subtitle={
+          <>
+            Explore <span className="text-accent font-semibold">3D orbit</span> of skills
+            and browse through categorized cards{" "}
+          </>
+        }
+        withDivider
+      >
+        Experiments{" "}
+      </SectionHeading>
 
       <div className="flex flex-col !justify-center md:grid md:grid-cols-2 gap-6 md:gap-8 items-center mx-auto">
         <div className="flex-1 h-[50vh] md:h-[calc(100dvh-12rem)] relative rounded-xl flex items-center justify-center">
@@ -183,6 +164,6 @@ export const Skills = () => {
           </div>
         </div>
       </div>
-    </section>
+    </SectionContainer>
   );
 };

--- a/apps/web/src/constants/config.ts
+++ b/apps/web/src/constants/config.ts
@@ -35,3 +35,14 @@ export const SECTION_IDS = {
   experiences: "experiences",
   skills: "skills",
 } as const;
+
+export const SKILL_CATEGORIES = [
+  "All",
+  "Frontend",
+  "Backend",
+  "DevOps",
+  "Database",
+  "Project Management",
+] as const;
+
+export type SkillCategoryFilter = (typeof SKILL_CATEGORIES)[number];


### PR DESCRIPTION
## Summary

Phase 4 of repo overhaul. Establishes the `atoms/` tier of the atomic design pyramid (previously empty) and pulls duplicated JSX out of section orchestrators into reusable primitives.

> **Stacked on #43 → #42 → #41 → development.** Merge in order.

## New atoms (`src/components/atoms/`)

| Atom               | Replaces                                                                 | Reuse |
| ------------------ | ------------------------------------------------------------------------ | ----- |
| `GradientText`     | Inline `bg-gradient-to-r from-accent to-primary bg-clip-text text-transparent` | **8 sites** |
| `SectionContainer` | Inline `<section ref={...} className={... isVisible ? ... : ...}>` reveal | **4 sites** |
| `SectionHeading`   | Composed gradient `<h2>` + optional subtitle + optional brand divider     | 3 sites   |

`SectionContainer` keeps the same public API the future Framer Motion variant will use, so the Phase 6 cutover (Tailwind transition → `motion.section` `whileInView`) becomes a single-file change.

## New molecules (`src/components/molecules/`)

- **`LoveCard`** — extracted from `about.tsx`: the 70-line "What I Love" card with the domino-reveal hover effect.
- **`CvDownloadCard`** — extracted from `about.tsx`: gradient download button + hover-to-scroll preview screenshot, including its local `isHovered` state.

## Constants

- `SKILL_CATEGORIES` + `SkillCategoryFilter` lifted from `sections/skills.tsx` into `constants/config.ts` so the filter list has a single source of truth.

## Cleanup

- `Footer`: dropped the `loading: boolean` prop (always called with `false` after Phase 3 removed loading branches). Matching call-site update in `PageWrapper`.

## LOC impact (section orchestrators)

| File                  | Before | After | Δ      |
| --------------------- | -----: | ----: | -----: |
| `about.tsx`           | 320    | 165   | **−48%** |
| `skills.tsx`          | 188    | 158   | −16%   |
| `experiences.tsx`     | 89     | 73    | −18%   |
| `projects.tsx`        | 68     | 55    | −19%   |
| **Total**             | **665** | **451** | **−32%** |

## Test plan

- [x] `npm run lint` — clean.
- [x] `next build` — succeeds; static + SSG + dynamic routes all build (DB connectivity confirmed).
- [ ] Smoke-test in `npm run dev`:
  - [ ] All section reveals trigger correctly when scrolling.
  - [ ] CV preview hover-to-scroll + download button still work.
  - [ ] "What I Love" hover-domino animation still triggers.
  - [ ] Skills 3D viewer still renders + filter still works.
  - [ ] Project detail page (`/projects/[slug]`) still works.