### PR TITLE
feat(perf,seo): dynamic 3D, ISR, sitemap, JSON-LD, OG image, top loading bar

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
+    "postinstall": "prisma generate",
     "db:seed": "ts-node --compiler-options {\\\"module\\\":\\\"commonjs\\\"} prisma/seed.ts",
     "images:optimize": "node scripts/optimize-images.mjs"
   },

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,19 +1,112 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Outfit } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
+
 import { ThemeProvider } from "./providers/ThemeProvider";
 import { QueryProvider } from "./providers/QueryProvider";
+import { TopProgressBar } from "@/components/atoms/TopProgressBar";
+import { EXTERNAL_LINKS, SITE_CONFIG } from "@/constants/config";
 import "./globals.css";
 
 const geistOutfit = Outfit({
   variable: "--font-outfit",
   subsets: ["latin"],
+  display: "swap",
 });
 
+const title = `${SITE_CONFIG.author} | Software Engineer`;
+const description =
+  "A personal space to sharpen my skills while exploring and experimenting with new tech stacks I haven't tried before — featuring projects, experiences, and an interactive 3D skills viewer.";
+
 export const metadata: Metadata = {
-  title: "Shendy Putra P. Y. | Software Engineer",
-  description:
-    "A personal space to sharpen my skills while exploring and experimenting with new tech stacks I haven't tried before",
+  metadataBase: new URL(SITE_CONFIG.url),
+  title: {
+    default: title,
+    template: `%s | ${SITE_CONFIG.author}`,
+  },
+  description,
+  applicationName: SITE_CONFIG.title,
+  authors: [{ name: SITE_CONFIG.author, url: EXTERNAL_LINKS.linkedin }],
+  creator: SITE_CONFIG.author,
+  keywords: [
+    "Shendy Putra Perdana Yohansah",
+    "Shendy Yohansah",
+    "Software Engineer",
+    "Front-End Developer",
+    "Full Stack Developer",
+    "React",
+    "Next.js",
+    "TypeScript",
+    "Three.js",
+    "Portfolio",
+    "Indonesia",
+  ],
+  alternates: { canonical: "/" },
+  openGraph: {
+    type: "website",
+    locale: SITE_CONFIG.locale,
+    url: SITE_CONFIG.url,
+    siteName: SITE_CONFIG.title,
+    title,
+    description,
+    images: [{ url: "/opengraph-image", width: 1200, height: 630, alt: title }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+    creator: "@shendyppy",
+    images: ["/opengraph-image"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+  icons: {
+    icon: "/favicon.ico",
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },
+  ],
+  width: "device-width",
+  initialScale: 1,
+};
+
+const personJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: SITE_CONFIG.author,
+  alternateName: "Shenks",
+  url: SITE_CONFIG.url,
+  image: `${SITE_CONFIG.url}${SITE_CONFIG.profileImage}`,
+  jobTitle: "Software Engineer",
+  description,
+  email: `mailto:${EXTERNAL_LINKS.email}`,
+  sameAs: [
+    EXTERNAL_LINKS.github,
+    EXTERNAL_LINKS.linkedin,
+    EXTERNAL_LINKS.instagram,
+    EXTERNAL_LINKS.twitter,
+  ],
+  knowsAbout: [
+    "React",
+    "Next.js",
+    "TypeScript",
+    "Three.js",
+    "Node.js",
+    "PostgreSQL",
+    "Prisma",
+  ],
 };
 
 export default function RootLayout({
@@ -24,8 +117,15 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistOutfit.variable} antialiased`}>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+        />
         <QueryProvider>
-          <ThemeProvider>{children}</ThemeProvider>
+          <ThemeProvider>
+            <TopProgressBar />
+            {children}
+          </ThemeProvider>
         </QueryProvider>
         <Analytics />
       </body>

--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -1,0 +1,99 @@
+import { ImageResponse } from "next/og";
+import { SITE_CONFIG } from "@/constants/config";
+
+export const runtime = "edge";
+export const alt = `${SITE_CONFIG.author} — Software Engineer`;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "80px",
+          background:
+            "linear-gradient(135deg, #0a0a0a 0%, #1a1a2e 50%, #16213e 100%)",
+          color: "#ffffff",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "16px",
+            fontSize: "28px",
+            color: "#a5b4fc",
+            marginBottom: "16px",
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
+          }}
+        >
+          <div
+            style={{
+              width: "12px",
+              height: "12px",
+              borderRadius: "50%",
+              background: "linear-gradient(90deg, #6366f1, #f472b6)",
+            }}
+          />
+          shendyppy.vercel.app
+        </div>
+
+        <div
+          style={{
+            fontSize: "96px",
+            fontWeight: 800,
+            lineHeight: 1.05,
+            letterSpacing: "-0.03em",
+            background:
+              "linear-gradient(90deg, #818cf8 0%, #c084fc 50%, #f472b6 100%)",
+            backgroundClip: "text",
+            color: "transparent",
+            marginBottom: "24px",
+          }}
+        >
+          {SITE_CONFIG.author}
+        </div>
+
+        <div
+          style={{
+            fontSize: "44px",
+            color: "#e2e8f0",
+            fontWeight: 500,
+            marginBottom: "40px",
+          }}
+        >
+          Software Engineer · Front-End · Full-Stack
+        </div>
+
+        <div
+          style={{
+            fontSize: "28px",
+            color: "#94a3b8",
+            display: "flex",
+            gap: "32px",
+            alignItems: "center",
+          }}
+        >
+          <span>React</span>
+          <span style={{ color: "#475569" }}>·</span>
+          <span>Next.js</span>
+          <span style={{ color: "#475569" }}>·</span>
+          <span>TypeScript</span>
+          <span style={{ color: "#475569" }}>·</span>
+          <span>Three.js</span>
+          <span style={{ color: "#475569" }}>·</span>
+          <span>Prisma</span>
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,10 @@
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
+// Re-render once per hour at most. Content rarely changes; ISR keeps the
+// landing page fully static-cacheable while still picking up DB edits
+// without a full redeploy.
+export const revalidate = 3600;
+
 import { PageWrapper } from "@/components/organisms/PageWrapper";
 import { Hero3D } from "@/components/sections/hero3d";
 import { Projects } from "@/components/sections/projects";

--- a/apps/web/src/app/projects/[slug]/page.tsx
+++ b/apps/web/src/app/projects/[slug]/page.tsx
@@ -3,7 +3,13 @@ import type { Metadata } from "next";
 
 import { ProjectPageContent } from "@/components/organisms/ProjectPageContent";
 import { getProjectBySlug, getProjects } from "@/server/queries/projects";
+import { SITE_CONFIG } from "@/constants/config";
 import type { ProjectDetail, ProjectHighlight } from "@/types";
+
+// Re-render once per hour at most. Content rarely changes; ISR gives us
+// near-static performance while still picking up DB edits.
+export const revalidate = 3600;
+export const dynamicParams = true;
 
 type ProjectWithHighlights = NonNullable<Awaited<ReturnType<typeof getProjectBySlug>>>;
 
@@ -21,13 +27,27 @@ export const generateMetadata = async ({
   const project = await getProjectBySlug(slug);
   if (!project) return { title: "Project Not Found" };
 
+  const title = `${project.company} — ${project.title}`;
+  const description = project.overview ?? project.description;
+  const url = `/projects/${slug}`;
+
   return {
-    title: `${project.company} | Shendy's Portfolio`,
-    description: project.title,
+    title,
+    description,
+    alternates: { canonical: url },
     openGraph: {
-      title: `${project.company} | Shendy's Portfolio`,
-      description: project.title,
-      type: "website",
+      title,
+      description,
+      url,
+      type: "article",
+      siteName: SITE_CONFIG.title,
+      images: project.image ? [{ url: project.image, alt: title }] : undefined,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: project.image ? [project.image] : undefined,
     },
   };
 };

--- a/apps/web/src/app/projects/[slug]/page.tsx
+++ b/apps/web/src/app/projects/[slug]/page.tsx
@@ -14,8 +14,20 @@ export const dynamicParams = true;
 type ProjectWithHighlights = NonNullable<Awaited<ReturnType<typeof getProjectBySlug>>>;
 
 export const generateStaticParams = async () => {
-  const projects = await getProjects();
-  return projects.map((project) => ({ slug: project.slug }));
+  // If the DB is unreachable at build time (Neon cold start, network blip,
+  // missing DATABASE_URL on a preview), fall back to an empty list. With
+  // `dynamicParams: true` above, pages will be generated + ISR-cached on
+  // first request instead of failing the entire build.
+  try {
+    const projects = await getProjects();
+    return projects.map((project) => ({ slug: project.slug }));
+  } catch (error) {
+    console.warn(
+      "[generateStaticParams] DB unreachable; pages will generate on-demand.",
+      error
+    );
+    return [];
+  }
 };
 
 export const generateMetadata = async ({

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+import { SITE_CONFIG } from "@/constants/config";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/"],
+      },
+    ],
+    sitemap: `${SITE_CONFIG.url}/sitemap.xml`,
+    host: SITE_CONFIG.url,
+  };
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from "next";
+import { getProjects } from "@/server/queries/projects";
+import { SITE_CONFIG } from "@/constants/config";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = SITE_CONFIG.url;
+  const now = new Date();
+
+  const projects = await getProjects();
+
+  const projectEntries: MetadataRoute.Sitemap = projects.map((project) => ({
+    url: `${baseUrl}/projects/${project.slug}`,
+    lastModified: now,
+    changeFrequency: "monthly",
+    priority: 0.7,
+  }));
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    ...projectEntries,
+  ];
+}

--- a/apps/web/src/components/atoms/TopProgressBar.tsx
+++ b/apps/web/src/components/atoms/TopProgressBar.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Suspense, useEffect, useRef, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { AnimatePresence, motion } from "framer-motion";
+
+/**
+ * App Router-native top loading bar — NProgress in spirit, but built on
+ * Framer Motion + pathname detection so we get brand-gradient styling
+ * (accent → primary) and reduced-motion support out of the box.
+ *
+ * Why pathname detection (and not Next.js `useLinkStatus`):
+ * `useLinkStatus` is a per-Link hook — it must be a child of <Link> and
+ * only knows about that one navigation. For a global top bar we'd have
+ * to migrate every <Link> in the codebase. Intercepting clicks on
+ * <a href="/internal"> + watching pathname/searchParams is functionally
+ * equivalent and stays decoupled from the Link API.
+ */
+
+const Bar = () => {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const previousLocation = useRef<string>("");
+  const [progress, setProgress] = useState(0);
+  const [visible, setVisible] = useState(false);
+  const completionTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const climbTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Click interception → start the bar for internal navigations.
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      // Skip modified clicks (cmd/ctrl/shift) — they open new tabs.
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.button !== 0) return;
+
+      const link = (event.target as HTMLElement | null)?.closest("a");
+      if (!link) return;
+
+      const href = link.getAttribute("href");
+      if (!href) return;
+      if (href.startsWith("#") || href.startsWith("mailto:") || href.startsWith("tel:")) return;
+      if (link.target === "_blank") return;
+      if (link.hasAttribute("download")) return;
+
+      try {
+        const url = new URL(href, window.location.href);
+        if (url.origin !== window.location.origin) return;
+        if (
+          url.pathname === window.location.pathname &&
+          url.search === window.location.search
+        ) {
+          return;
+        }
+      } catch {
+        return;
+      }
+
+      // Start: jump to 15%, then climb to 80% over ~600ms.
+      setVisible(true);
+      setProgress(15);
+      if (climbTimer.current) clearTimeout(climbTimer.current);
+      climbTimer.current = setTimeout(() => setProgress(80), 80);
+    };
+
+    document.addEventListener("click", handleClick, { capture: true });
+    return () =>
+      document.removeEventListener("click", handleClick, { capture: true });
+  }, []);
+
+  // Pathname (or query) actually changed → finish the bar.
+  useEffect(() => {
+    const next = `${pathname}?${searchParams?.toString() ?? ""}`;
+    if (previousLocation.current === "") {
+      previousLocation.current = next;
+      return;
+    }
+    if (next === previousLocation.current) return;
+    previousLocation.current = next;
+
+    setProgress(100);
+    if (completionTimer.current) clearTimeout(completionTimer.current);
+    completionTimer.current = setTimeout(() => {
+      setVisible(false);
+      setTimeout(() => setProgress(0), 300);
+    }, 220);
+  }, [pathname, searchParams]);
+
+  return (
+    <AnimatePresence>
+      {visible ? (
+        <motion.div
+          key="top-progress-bar"
+          className="fixed top-0 left-0 right-0 z-[9999] h-[3px] origin-left bg-gradient-to-r from-accent to-primary shadow-[0_0_10px_rgba(99,102,241,0.6)]"
+          initial={{ scaleX: 0, opacity: 0 }}
+          animate={{
+            scaleX: progress / 100,
+            opacity: 1,
+          }}
+          exit={{ opacity: 0 }}
+          transition={{
+            scaleX: {
+              duration: progress === 100 ? 0.18 : progress > 50 ? 0.6 : 0.25,
+              ease: progress === 100 ? "easeOut" : "easeOut",
+            },
+            opacity: { duration: 0.25 },
+          }}
+        />
+      ) : null}
+    </AnimatePresence>
+  );
+};
+
+/**
+ * Public component. Wrapped in Suspense because `useSearchParams` requires
+ * one in App Router (otherwise the entire page bails out of static
+ * generation).
+ */
+export const TopProgressBar = () => (
+  <Suspense fallback={null}>
+    <Bar />
+  </Suspense>
+);

--- a/apps/web/src/components/molecules/HeroScene.tsx
+++ b/apps/web/src/components/molecules/HeroScene.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Suspense } from "react";
+import { Canvas } from "@react-three/fiber";
+import { OrbitControls, Text3D, Environment, Float } from "@react-three/drei";
+
+import { scene3DColors } from "@/constants/colors";
+import type { Theme } from "@/types";
+
+const FloatingCube = ({
+  position,
+  color,
+}: {
+  position: [number, number, number];
+  color: string;
+}) => (
+  <Float speed={3} rotationIntensity={1} floatIntensity={2}>
+    <mesh position={position}>
+      <boxGeometry args={[0.5, 0.5, 0.5]} />
+      <meshStandardMaterial color={color} />
+    </mesh>
+  </Float>
+);
+
+const Scene3D = ({ theme, isSmUp }: { theme: Theme; isSmUp: boolean }) => {
+  const colors = scene3DColors[theme];
+
+  return (
+    <>
+      <ambientLight intensity={0.5} />
+      <pointLight position={[10, 10, 10]} />
+      <Environment preset="studio" />
+
+      {isSmUp ? (
+        <Text3D
+          font="/fonts/Press Start 2P.json"
+          size={1}
+          height={0.2}
+          position={[-1.5, 1.5, -1.2]}
+        >
+          Hi,
+          <meshStandardMaterial color={colors.text} />
+        </Text3D>
+      ) : null}
+
+      <FloatingCube position={[3, 1, 0]} color={colors.cubes[0]} />
+      <FloatingCube position={[-3, -1.5, -5]} color={colors.cubes[1]} />
+      <FloatingCube position={[-3, -1, 1]} color={colors.cubes[2]} />
+      <FloatingCube position={[2, -1.5, -1]} color={colors.cubes[3]} />
+
+      <OrbitControls enableZoom={false} enablePan={false} />
+    </>
+  );
+};
+
+type HeroSceneProps = {
+  theme: Theme;
+  isSmUp: boolean;
+};
+
+/**
+ * 3D hero scene. Extracted into its own module so the heavy R3F + drei +
+ * three bundle is split out via `next/dynamic` from the parent. The text
+ * + traits in the hero render immediately while this scene streams in.
+ */
+const HeroScene = ({ theme, isSmUp }: HeroSceneProps) => (
+  <Canvas camera={{ position: [0, 0, 5], fov: 75 }}>
+    <Suspense fallback={null}>
+      <Scene3D theme={theme} isSmUp={isSmUp} />
+    </Suspense>
+  </Canvas>
+);
+
+export default HeroScene;

--- a/apps/web/src/components/molecules/SkillCanvas.tsx
+++ b/apps/web/src/components/molecules/SkillCanvas.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Suspense } from "react";
+import * as THREE from "three";
+import { Canvas } from "@react-three/fiber";
+import { useGLTF, OrbitControls } from "@react-three/drei";
+
+import type { Skill } from "@/types";
+
+const SkillModel = ({ skill, theme }: { skill: Skill; theme: string }) => {
+  const glb = useGLTF(skill.model);
+
+  const box = new THREE.Box3().setFromObject(glb.scene);
+  const size = box.getSize(new THREE.Vector3());
+  const maxDimension = Math.max(size.x, size.y, size.z);
+  const targetSize = 2.5;
+  const scale = maxDimension > 0 ? targetSize / maxDimension : 1.2;
+
+  glb.scene.traverse((child: THREE.Object3D) => {
+    if ((child as THREE.Mesh).isMesh) {
+      (child as THREE.Mesh).material = new THREE.MeshStandardMaterial({
+        color:
+          theme === "dark"
+            ? new THREE.Color(skill.color).offsetHSL(0, 0, 0.1)
+            : skill.color,
+        metalness: 0.3,
+        roughness: 0.6,
+        side: THREE.DoubleSide,
+      });
+    }
+  });
+
+  return (
+    <group rotation={[Math.PI / 2, 0, 0]} scale={scale}>
+      <primitive object={glb.scene} />
+    </group>
+  );
+};
+
+type SkillCanvasProps = {
+  skill: Skill;
+  theme: string;
+};
+
+/**
+ * 3D viewer for the Skills section. Extracted into its own module so the
+ * heavy R3F + drei + three bundle (~600 KB raw) is only loaded when this
+ * component renders, via `next/dynamic` from the parent.
+ */
+const SkillCanvas = ({ skill, theme }: SkillCanvasProps) => (
+  <Canvas camera={{ position: [0, 0, 12], fov: 60 }}>
+    <ambientLight intensity={theme === "dark" ? 0.4 : 0.7} />
+    <directionalLight
+      position={[5, 5, 5]}
+      intensity={theme === "dark" ? 1.5 : 2}
+    />
+    <Suspense fallback={null}>
+      <OrbitControls enableZoom autoRotate autoRotateSpeed={1} />
+      <SkillModel skill={skill} theme={theme} />
+    </Suspense>
+  </Canvas>
+);
+
+export default SkillCanvas;

--- a/apps/web/src/components/sections/hero3d.tsx
+++ b/apps/web/src/components/sections/hero3d.tsx
@@ -1,68 +1,25 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import { useState } from "react";
+import dynamic from "next/dynamic";
 import { ArrowDown } from "lucide-react";
-import { Canvas } from "@react-three/fiber";
-import { OrbitControls, Text3D, Environment, Float } from "@react-three/drei";
 
 import { Button } from "@/components/ui/button";
 import TypingText from "@/hooks/useTypingEffect";
 import { useThemeContext } from "@/app/providers/ThemeProvider";
-import { Theme, Trait } from "@/types";
+import { Trait } from "@/types";
 import { useMediaQuery } from "@/hooks/useResponsive";
 import { scrollToSection } from "@/lib/utils";
 import { heroTraits, heroBio } from "@/data/hero";
-import { traitColors, scene3DColors } from "@/constants/colors";
+import { traitColors } from "@/constants/colors";
 import { SECTION_IDS } from "@/constants/config";
 import { TraitBadge } from "@/components/molecules/TraitBadge";
 
-const FloatingCube = ({
-  position,
-  color,
-}: {
-  position: [number, number, number];
-  color: string;
-}) => {
-  return (
-    <Float speed={3} rotationIntensity={1} floatIntensity={2}>
-      <mesh position={position}>
-        <boxGeometry args={[0.5, 0.5, 0.5]} />
-        <meshStandardMaterial color={color} />
-      </mesh>
-    </Float>
-  );
-};
-
-const Scene3D = ({ theme, isSmUp }: { theme: Theme; isSmUp: boolean }) => {
-  const colors = scene3DColors[theme];
-
-  return (
-    <>
-      <ambientLight intensity={0.5} />
-      <pointLight position={[10, 10, 10]} />
-      <Environment preset="studio" />
-
-      {isSmUp && (
-        <Text3D
-          font="/fonts/Press Start 2P.json"
-          size={1}
-          height={0.2}
-          position={[-1.5, 1.5, -1.2]}
-        >
-          Hi,
-          <meshStandardMaterial color={colors.text} />
-        </Text3D>
-      )}
-
-      <FloatingCube position={[3, 1, 0]} color={colors.cubes[0]} />
-      <FloatingCube position={[-3, -1.5, -5]} color={colors.cubes[1]} />
-      <FloatingCube position={[-3, -1, 1]} color={colors.cubes[2]} />
-      <FloatingCube position={[2, -1.5, -1]} color={colors.cubes[3]} />
-
-      <OrbitControls enableZoom={false} enablePan={false} />
-    </>
-  );
-};
+// 3D scene streams in after the hero copy + traits are interactive.
+const HeroScene = dynamic(() => import("@/components/molecules/HeroScene"), {
+  ssr: false,
+  loading: () => null,
+});
 
 export const Hero3D = () => {
   const { theme } = useThemeContext();
@@ -127,11 +84,7 @@ export const Hero3D = () => {
       className="w-full sm:h-screen flex items-center justify-center overflow-hidden"
     >
       <div className="absolute inset-0 z-0">
-        <Canvas camera={{ position: [0, 0, 5], fov: 75 }}>
-          <Suspense fallback={null}>
-            <Scene3D theme={theme} isSmUp={isSmUp} />
-          </Suspense>
-        </Canvas>
+        <HeroScene theme={theme} isSmUp={isSmUp} />
       </div>
 
       <div className="flex flex-col justify-center text-center z-10 px-4 max-w-6xl mx-auto sm:mt-auto pt-20 pb-12 sm:py-20">

--- a/apps/web/src/components/sections/skills.tsx
+++ b/apps/web/src/components/sections/skills.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import React, { Suspense, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
+import dynamic from "next/dynamic";
 import { useQuery } from "@tanstack/react-query";
 
-import * as THREE from "three";
-import { Canvas } from "@react-three/fiber";
-import { useGLTF, OrbitControls } from "@react-three/drei";
-
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useThemeContext } from "@/app/providers/ThemeProvider";
 import { skillCategoryColors } from "@/constants/colors";
 import { SKILL_CATEGORIES, type SkillCategoryFilter } from "@/constants/config";
@@ -17,40 +15,21 @@ import { SectionContainer } from "@/components/atoms/SectionContainer";
 import { SectionHeading } from "@/components/atoms/SectionHeading";
 import { queryKeys } from "@/lib/query-keys";
 
+// Lazy-load the R3F + drei + three bundle (~600 KB) — only fetched when
+// the Skills section actually renders. ssr:false because Three.js needs
+// `window` and would crash the server.
+const SkillCanvas = dynamic(
+  () => import("@/components/molecules/SkillCanvas"),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="w-full h-full" />,
+  }
+);
+
 const fetchSkills = async (): Promise<Skill[]> => {
   const res = await fetch("/api/skills");
   if (!res.ok) throw new Error("Failed to fetch skills");
   return res.json();
-};
-
-const SkillModel = ({ skill, theme }: { skill: Skill; theme: string }) => {
-  const glb = useGLTF(skill.model);
-
-  const box = new THREE.Box3().setFromObject(glb.scene);
-  const size = box.getSize(new THREE.Vector3());
-  const maxDimension = Math.max(size.x, size.y, size.z);
-  const targetSize = 2.5;
-  const scale = maxDimension > 0 ? targetSize / maxDimension : 1.2;
-
-  glb.scene.traverse((child: THREE.Object3D) => {
-    if ((child as THREE.Mesh).isMesh) {
-      (child as THREE.Mesh).material = new THREE.MeshStandardMaterial({
-        color:
-          theme === "dark"
-            ? new THREE.Color(skill.color).offsetHSL(0, 0, 0.1)
-            : skill.color,
-        metalness: 0.3,
-        roughness: 0.6,
-        side: THREE.DoubleSide,
-      });
-    }
-  });
-
-  return (
-    <group rotation={[Math.PI / 2, 0, 0]} scale={scale}>
-      <primitive object={glb.scene} />
-    </group>
-  );
 };
 
 export const Skills = () => {
@@ -100,17 +79,7 @@ export const Skills = () => {
       <div className="flex flex-col !justify-center md:grid md:grid-cols-2 gap-6 md:gap-8 items-center mx-auto">
         <div className="flex-1 h-[50vh] md:h-[calc(100dvh-12rem)] relative rounded-xl flex items-center justify-center">
           <div className="w-full h-[300px] lg:h-full transition-all duration-500 ease-in-out animate-fadeIn">
-            <Canvas camera={{ position: [0, 0, 12], fov: 60 }}>
-              <ambientLight intensity={theme === "dark" ? 0.4 : 0.7} />
-              <directionalLight
-                position={[5, 5, 5]}
-                intensity={theme === "dark" ? 1.5 : 2}
-              />
-              <Suspense fallback={null}>
-                <OrbitControls enableZoom autoRotate autoRotateSpeed={1} />
-                <SkillModel skill={selectedSkill} theme={theme} />
-              </Suspense>
-            </Canvas>
+            <SkillCanvas skill={selectedSkill} theme={theme} />
           </div>
         </div>
 

--- a/apps/web/src/constants/config.ts
+++ b/apps/web/src/constants/config.ts
@@ -7,11 +7,20 @@ export const EXTERNAL_LINKS = {
   email: "shendyppy@gmail.com",
 };
 
+// Production canonical URL. Override via NEXT_PUBLIC_SITE_URL on preview /
+// non-default deploys (e.g. branch previews). Trailing slash intentionally
+// omitted so callers can append paths cleanly.
+const inferredUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ??
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "https://shendyppy.vercel.app");
+
 export const SITE_CONFIG = {
   author: "Shendy Putra Perdana Yohansah",
   title: "Shendy's Portfolio",
   description: "Front-End Developer specializing in React, TypeScript, and 3D web experiences",
   profileImage: "/assets/Shendy.webp",
+  url: inferredUrl,
+  locale: "en_US",
 };
 
 export const ANIMATION_DELAYS = {


### PR DESCRIPTION
## Summary

Phase 5 of repo overhaul. Production-readiness pass — performance, SEO, and a custom NProgress-style top loading bar bundled into one focused PR.

> **Stacked on #44 → #43 → #42 → #41 → development.** Merge in order.

## Performance — `−65%` initial JS

| Route                  | Before    | After    | Δ        |
| ---------------------- | --------: | -------: | -------: |
| `/` First Load JS      | **434 kB** | **150 kB** | **−65%** |
| `/projects/[slug]`     | 125 kB    | 125 kB    | (same)   |

- **Hero scene** + **Skills 3D viewer** extracted into `HeroScene.tsx` + `SkillCanvas.tsx`, then dynamic-imported via `next/dynamic` with `ssr:false`. The R3F + drei + three bundle (~600 KB raw) is no longer in the initial payload — it streams in after the hero copy + traits are interactive.
- **ISR** on landing (`/`) and project detail (`/projects/[slug]`): `export const revalidate = 3600`. Static-cached at the CDN, refreshes on a 1-hour window when content changes — no redeploy needed. Confirmed in build output (`1h Revalidate` column).

## SEO — full polish

- **Root layout metadata**: `metadataBase`, title template, full Open Graph + Twitter card, robots directives (`max-image-preview: large`, `max-snippet: -1`), keywords, canonical, applicationName, viewport `themeColor` for light/dark, font `display:swap`.
- **Person JSON-LD** (schema.org) injected in layout — name, image, jobTitle, sameAs (all socials), knowsAbout. Helps Google build the knowledge panel from this profile.
- **Per-project metadata** enriched: real description (overview falls back to description), canonical, Open Graph article type with project image, Twitter `summary_large_image`.
- **New routes:**
  - `app/sitemap.ts` — landing + every published project, with priorities.
  - `app/robots.ts` — allow all, disallow `/api/`, points at sitemap.
  - `app/opengraph-image.tsx` — 1200×630 PNG generated via `next/og` at the **edge** runtime. Branded gradient background with name + role + tech list.

## Custom NProgress

- `src/components/atoms/TopProgressBar.tsx`: 3px gradient bar (accent → primary), Framer Motion driven, `AnimatePresence` on visibility. Click-interception detects internal navigation start; `pathname`/`searchParams` change finishes the bar.
- **Why click + pathname (not Next.js `useLinkStatus`):** `useLinkStatus` is a per-Link hook and would require migrating every `<Link>` in the codebase. Pathname detection is functionally equivalent for a global bar and stays decoupled from the Link API. Documented in the component's header comment.

## Constants

- `SITE_CONFIG.url` + `.locale` added with `NEXT_PUBLIC_SITE_URL` / `VERCEL_URL` fallback chain so sitemap, robots, and OG metadata all point at the right host on previews and production.

## New build routes

```
├ ƒ /opengraph-image           ← edge-rendered PNG
├ ○ /robots.txt
├ ○ /sitemap.xml
```

## Test plan

- [x] `npm run lint` clean.
- [x] `next build` succeeds. Bundle stats verified — `/` First Load JS: **150 kB** (was 434 kB). ISR shows `1h Revalidate` for `/` and `/projects/[slug]`.
- [ ] Smoke-test in `npm run dev`:
  - [ ] Top loading bar appears + completes when navigating from `/` → `/projects/<slug>`.
  - [ ] Hero 3D scene streams in after first paint (no longer blocking).
  - [ ] Skills 3D viewer also lazy-loads when scrolled into view.
  - [ ] `/sitemap.xml` returns valid XML with all project URLs.
  - [ ] `/robots.txt` returns the expected directives.
  - [ ] `/opengraph-image` returns a 1200×630 PNG with the brand gradient.
- [ ] After merge: paste production URL into the LinkedIn post inspector to confirm OG image renders. Submit sitemap to Google Search Console.

## Production note

Set `NEXT_PUBLIC_SITE_URL` on Vercel for canonical URLs to point to the right host (otherwise falls back to `VERCEL_URL` which is per-deploy).